### PR TITLE
Fix/ci 

### DIFF
--- a/.github/workflows/ci-py310.yml
+++ b/.github/workflows/ci-py310.yml
@@ -9,7 +9,29 @@ permissions:
   contents: read
 
 jobs:
+  pr-trigger-check:
+    name: PR trigger check
+    runs-on: ubuntu-latest
+    outputs:
+      allow_ci: ${{ steps.check.outputs.allow_ci }}
+    steps:
+      - name: Determine whether to run CI
+        id: check
+        run: |
+          echo "actor=${GITHUB_ACTOR}"
+          allow=true
+          if [ "${GITHUB_ACTOR}" = "github-actions[bot]" ] || [ "${GITHUB_ACTOR}" = "github-actions" ]; then
+            allow=false
+          fi
+          last_msg=$(git log -1 --pretty=%B || true)
+          if echo "$last_msg" | grep -q "^chore(ci)"; then
+            allow=false
+          fi
+          echo "::set-output name=allow_ci::$allow"
+
   test:
+    needs: [pr-trigger-check]
+    if: needs.pr-trigger-check.outputs.allow_ci == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci-py311.yml
+++ b/.github/workflows/ci-py311.yml
@@ -9,7 +9,29 @@ permissions:
   contents: read
 
 jobs:
+  pr-trigger-check:
+    name: PR trigger check
+    runs-on: ubuntu-latest
+    outputs:
+      allow_ci: ${{ steps.check.outputs.allow_ci }}
+    steps:
+      - name: Determine whether to run CI
+        id: check
+        run: |
+          echo "actor=${GITHUB_ACTOR}"
+          allow=true
+          if [ "${GITHUB_ACTOR}" = "github-actions[bot]" ] || [ "${GITHUB_ACTOR}" = "github-actions" ]; then
+            allow=false
+          fi
+          last_msg=$(git log -1 --pretty=%B || true)
+          if echo "$last_msg" | grep -q "^chore(ci)"; then
+            allow=false
+          fi
+          echo "::set-output name=allow_ci::$allow"
+
   test:
+    needs: [pr-trigger-check]
+    if: needs.pr-trigger-check.outputs.allow_ci == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci-py312.yml
+++ b/.github/workflows/ci-py312.yml
@@ -9,7 +9,29 @@ permissions:
   contents: read
 
 jobs:
+  pr-trigger-check:
+    name: PR trigger check
+    runs-on: ubuntu-latest
+    outputs:
+      allow_ci: ${{ steps.check.outputs.allow_ci }}
+    steps:
+      - name: Determine whether to run CI
+        id: check
+        run: |
+          echo "actor=${GITHUB_ACTOR}"
+          allow=true
+          if [ "${GITHUB_ACTOR}" = "github-actions[bot]" ] || [ "${GITHUB_ACTOR}" = "github-actions" ]; then
+            allow=false
+          fi
+          last_msg=$(git log -1 --pretty=%B || true)
+          if echo "$last_msg" | grep -q "^chore(ci)"; then
+            allow=false
+          fi
+          echo "::set-output name=allow_ci::$allow"
+
   test:
+    needs: [pr-trigger-check]
+    if: needs.pr-trigger-check.outputs.allow_ci == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci-py313.yml
+++ b/.github/workflows/ci-py313.yml
@@ -9,7 +9,29 @@ permissions:
   contents: read
 
 jobs:
+  pr-trigger-check:
+    name: PR trigger check
+    runs-on: ubuntu-latest
+    outputs:
+      allow_ci: ${{ steps.check.outputs.allow_ci }}
+    steps:
+      - name: Determine whether to run CI
+        id: check
+        run: |
+          echo "actor=${GITHUB_ACTOR}"
+          allow=true
+          if [ "${GITHUB_ACTOR}" = "github-actions[bot]" ] || [ "${GITHUB_ACTOR}" = "github-actions" ]; then
+            allow=false
+          fi
+          last_msg=$(git log -1 --pretty=%B || true)
+          if echo "$last_msg" | grep -q "^chore(ci)"; then
+            allow=false
+          fi
+          echo "::set-output name=allow_ci::$allow"
+
   test:
+    needs: [pr-trigger-check]
+    if: needs.pr-trigger-check.outputs.allow_ci == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci-quick-checks.yml
+++ b/.github/workflows/ci-quick-checks.yml
@@ -7,8 +7,34 @@ on:
     branches: [ main, update-2025.0.1 ]
 
 jobs:
+  pr-trigger-check:
+    name: PR trigger check
+    runs-on: ubuntu-latest
+    outputs:
+      allow_ci: ${{ steps.check.outputs.allow_ci }}
+    steps:
+      - name: Determine whether to run CI
+        id: check
+        run: |
+          echo "actor=${GITHUB_ACTOR}"
+          # default to true
+          allow=true
+          # If the run was triggered by the GitHub Actions bot, skip CI
+          if [ "${GITHUB_ACTOR}" = "github-actions[bot]" ] || [ "${GITHUB_ACTOR}" = "github-actions" ]; then
+            allow=false
+          fi
+          # If the latest commit message starts with chore(ci), skip CI
+          last_msg=$(git log -1 --pretty=%B || true)
+          if echo "$last_msg" | grep -q "^chore(ci)"; then
+            allow=false
+          fi
+          echo "allow_ci=$allow"
+          echo "::set-output name=allow_ci::$allow"
+
   quick:
     name: Quick checks (lint, type)
+    needs: [pr-trigger-check]
+    if: needs.pr-trigger-check.outputs.allow_ci == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/update-coverage-badge.yml
+++ b/.github/workflows/update-coverage-badge.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   update-coverage:

--- a/.github/workflows/upload-diagnostics.yml
+++ b/.github/workflows/upload-diagnostics.yml
@@ -7,7 +7,29 @@ on:
     branches: [ main ]
 
 jobs:
+  pr-trigger-check:
+    name: PR trigger check
+    runs-on: ubuntu-latest
+    outputs:
+      allow_ci: ${{ steps.check.outputs.allow_ci }}
+    steps:
+      - name: Determine whether to run CI
+        id: check
+        run: |
+          echo "actor=${GITHUB_ACTOR}"
+          allow=true
+          if [ "${GITHUB_ACTOR}" = "github-actions[bot]" ] || [ "${GITHUB_ACTOR}" = "github-actions" ]; then
+            allow=false
+          fi
+          last_msg=$(git log -1 --pretty=%B || true)
+          if echo "$last_msg" | grep -q "^chore(ci)"; then
+            allow=false
+          fi
+          echo "::set-output name=allow_ci::$allow"
+
   tests-with-diagnostics:
+    needs: [pr-trigger-check]
+    if: needs.pr-trigger-check.outputs.allow_ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request introduces a new pre-check step in several GitHub Actions workflows to control when CI jobs are triggered. The main goal is to prevent unnecessary CI runs for commits made by automation bots or for commits with messages indicating CI-related chores. Additionally, a minor permission update is made to allow workflows to write to pull requests.

Key changes:

**CI Trigger Control Enhancements:**

* Added a `pr-trigger-check` job to the following workflows: `ci-quick-checks.yml`, `ci-py310.yml`, `ci-py311.yml`, `ci-py312.yml`, `ci-py313.yml`, and `upload-diagnostics.yml`. This job checks if the workflow was triggered by a bot or if the latest commit message starts with `chore(ci)`, and sets an output to allow or skip subsequent CI jobs. [[1]](diffhunk://#diff-5542919fd48b702b5c129e1ff39f958d687ed9fcf8ccab63da091170e3588877R10-R37) [[2]](diffhunk://#diff-2ee83d6ab360acdfc9ce161a949c769dd4d5e18f4f0ee241d24162e859acc12eR12-R34) [[3]](diffhunk://#diff-3c7e43d30e8d63cbf09fd593f4dd632ef0c2a38e9140695be451851de5396fbdR12-R34) [[4]](diffhunk://#diff-6cfd636690e5df725e7d6a871a0de01fd87ae34e1bcb34e973f6a0d60fe19331R12-R34) [[5]](diffhunk://#diff-1461f90be127b1af5ea7c3b4796de0e3216bd30ee46c6546741007a26e6f84d3R12-R34) [[6]](diffhunk://#diff-abed27d5622048b5b0b11a9b9716649f942ebe4f18a43004442d808d5edd97a4R10-R32)
* Updated dependent CI/test jobs in these workflows to require and conditionally run based on the output of the new `pr-trigger-check` job, effectively skipping unnecessary CI runs. [[1]](diffhunk://#diff-5542919fd48b702b5c129e1ff39f958d687ed9fcf8ccab63da091170e3588877R10-R37) [[2]](diffhunk://#diff-2ee83d6ab360acdfc9ce161a949c769dd4d5e18f4f0ee241d24162e859acc12eR12-R34) [[3]](diffhunk://#diff-3c7e43d30e8d63cbf09fd593f4dd632ef0c2a38e9140695be451851de5396fbdR12-R34) [[4]](diffhunk://#diff-6cfd636690e5df725e7d6a871a0de01fd87ae34e1bcb34e973f6a0d60fe19331R12-R34) [[5]](diffhunk://#diff-1461f90be127b1af5ea7c3b4796de0e3216bd30ee46c6546741007a26e6f84d3R12-R34) [[6]](diffhunk://#diff-abed27d5622048b5b0b11a9b9716649f942ebe4f18a43004442d808d5edd97a4R10-R32)

**Permissions Update:**

* Granted `pull-requests: write` permission in `update-coverage-badge.yml` to enable the workflow to update pull requests as needed.