### PR TITLE
Chore/simplificaton

### DIFF
--- a/docs/plans/plan-simplification-assert-transformer-2025-09-28.md
+++ b/docs/plans/plan-simplification-assert-transformer-2025-09-28.md
@@ -1,0 +1,144 @@
+# Plan: Simplify `wrap_assert_in_block` (2025-09-28)
+
+Goal: Decompose `wrap_assert_in_block()` in `splurge_unittest_to_pytest/transformers/assert_transformer.py` into smaller single-responsibility functions, implement the refactor incrementally, and keep behavior identical (conservative fallbacks on errors).
+
+Checklist (implementation in small, verifiable steps):
+
+- [x] Read and analyze `wrap_assert_in_block` and identify responsibilities (done).
+
+- [x] Draft decomposition and helper function list (high-level plan):
+  - `get_self_attr_call(stmt)`: detect bare `self`/`cls` attribute call statements.
+  - `build_with_item_from_assert_call(call_expr)`: build `WithItem` (pytest.warns/raises/caplog.at_level) from `self.assert*` call.
+  - `create_with_wrapping_next_stmt(with_item, next_stmt)`: produce a `With` node wrapping next statement or `pass`.
+  - `transform_standalone_assert_calls(statements)`: scan and replace standalone assert calls with With blocks.
+  - `transform_with_items(stmt)`: rewrite items inside existing `With`s to pytest equivalents and detect alias names.
+  - `rewrite_asserts_using_alias_in_with_body(with_node, alias_name)`: rewrite asserts inside a With body referencing an alias to `caplog.records` / `.getMessage()`.
+  - `rewrite_following_statements_for_alias(statements, alias_name, start_index, look_ahead)`: look-ahead rewrites after a With.
+  - `rewrite_assert_stmt_for_alias(node, alias_name)`: helper to rewrite a single statement referencing alias.
+
+- [x] Create plan doc (this file).
+
+- [x] Start implementing (small, safe first step):
+  - [x] Add `get_self_attr_call` and `build_with_item_from_assert_call` helpers above `wrap_assert_in_block`.
+  - [ ] Add tests for these helpers (unit tests).
+
+Detailed helper list and associated tests
+---------------------------------------
+
+The following helpers will be implemented one-by-one. For each helper I list:
+- signature (pythonic)
+- responsibility
+- inputs/outputs
+- key edge cases and invariants
+- the unit tests to add (file + test behavior)
+
+1) _get_self_attr_call(stmt: cst.BaseStatement) -> tuple[str, cst.Call] | None
+   - Responsibility: Detect a bare expression statement that is a `self`/`cls` attribute call (e.g., `self.assertLogs(...)`) and return the attribute name and the call node.
+   - Inputs/Outputs: Input is any `cst.BaseStatement`. Output is (attr_name, Call) or None.
+   - Edge cases: Only accept `SimpleStatementLine` with exactly one `Expr`; ignore other shapes. Only match when the attribute base is `self` or `cls`.
+   - Tests (unit): `tests/unit/test_assert_transformer_helpers.py`
+     - test_get_self_attr_call_matches_self_expr: parse `self.assertLogs('x')` as statement and assert returns ("assertLogs", Call).
+     - test_get_self_attr_call_none_for_non_expr: pass an `Assign` or other statement and assert None.
+
+2) _build_with_item_from_assert_call(call_expr: cst.Call) -> cst.WithItem | None
+   - Responsibility: Given a Call whose func is `self`/`cls` attribute, produce the correct `WithItem` for known context-asserts: `assertWarns`, `assertWarnsRegex`, `assertRaises`, `assertRaisesRegex`, `assertLogs`, `assertNoLogs`.
+   - Inputs/Outputs: Input: `cst.Call` node. Output: `cst.WithItem` or None.
+   - Edge cases: map keyword `match=` for regex/warns, use default caplog level of "INFO" when level missing, avoid preserving `as` alias for caplog conversion (tests depend on using `caplog` fixture), preserve `pytest.raises` signature arguments (as in original file).
+   - Tests (unit): `tests/unit/test_assert_transformer_helpers.py`
+     - test_build_with_item_warns_and_match: call_expr for `self.assertWarns(Exception, match='x')` yields WithItem wrapping `pytest.warns(Exception, match='x')`.
+     - test_build_with_item_assertlogs_default_level: `self.assertLogs('logger')` yields `caplog.at_level("INFO")` WithItem.
+     - test_build_with_item_raises: `self.assertRaises(MyErr)` yields `pytest.raises(MyErr)` WithItem.
+
+3) _create_with_wrapping_next_stmt(with_item: cst.WithItem, next_stmt: cst.BaseStatement | None) -> cst.With
+   - Responsibility: Given a WithItem and an optional next statement, produce a `cst.With` whose body is either the next statement (unwrapping inner With bodies if next_stmt is itself a With) or a `pass` body when next_stmt is None.
+   - Inputs/Outputs: WithItem and optional statement -> With node.
+   - Edge cases: If next_stmt is a `With`, use its inner `body` rather than nesting With -> keep same `IndentedBlock` shape.
+   - Tests (unit): `tests/unit/test_assert_transformer_with_creation.py`
+     - test_create_with_wraps_statement: ensure `with caplog.at_level(...): <stmt>` produced.
+     - test_create_with_unwraps_inner_with: next_stmt is a With with body -> resulting With should contain inner body.
+     - test_create_with_pass_when_none: next_stmt None -> body contains `pass`.
+
+4) transform_standalone_assert_calls(statements: list[cst.BaseStatement]) -> list[cst.BaseStatement]
+   - Responsibility: Full pass over statement list, detecting bare `self`/`cls` assert-calls and replacing them with `With` nodes that wrap the following statement or pass. This is a small orchestrating helper that uses the three helpers above.
+   - Inputs/Outputs: List of statements -> new list of statements (same length or shorter if wrapping consumes following statement).
+   - Edge cases: preserve index stepping (advance by 2 when wrapping); preserve unaffected statements; keep conservative behavior if helper returns None.
+   - Tests (integration/unit): `tests/unit/test_assert_transformer_wrap_and_alias.py` (existing) and new tests in `tests/unit/test_assert_transformer_wrap_creation.py`
+     - test_wrap_assert_logs_followed_by_stmt: input lines [self.assertLogs(...), assert len(log.output) == 2] -> With wrapping and body containing len rewrite later stages.
+     - test_wrap_assert_no_following_stmt: single `self.assertLogs(...)` -> With with pass body.
+
+5) transform_with_items(stmt: cst.With) -> tuple[cst.With, str | None, bool]
+   - Responsibility: Given a `With` node, rewrite items that are `self`/`cls` attribute calls into pytest equivalents (warns, raises, caplog.at_level). Return the new With, detected alias name if any (original `as X`), and a `changed` flag.
+   - Inputs/Outputs: `cst.With` -> (new `cst.With`, alias_name or None, changed flag)
+   - Edge cases/invariants: preserve `asname` for `raises` (original code preserved item.asname for raises); do not preserve alias for caplog conversions (tests expect caplog fixture). Keep try/except fallback around whole transformation.
+   - Tests (unit): `tests/unit/test_assert_transformer_with_items.py`
+     - test_transform_with_items_assertlogs_as_alias: `with self.assertLogs(...) as log:` -> With containing `caplog.at_level(...)` without `as` alias and returns alias_name == 'log'.
+     - test_transform_with_items_raises_preserve_as: `with self.assertRaises(E) as cm:` -> new WithItem with `pytest.raises(E)` and `asname` preserved.
+
+6) rewrite_asserts_using_alias_in_with_body(with_node: cst.With, alias_name: str) -> cst.With
+   - Responsibility: Given a With whose original WithItem had an alias name, rewrite `Assert` statements and `SimpleStatementLine`-wrapped asserts inside the With body to reference `caplog.records` instead of `alias.output`, and to insert `.getMessage()` on records when required (membership/equality patterns).
+   - Inputs/Outputs: `cst.With`, alias_name -> rewritten `cst.With` (or original on failure)
+   - Edge cases: handle both `Assert` and `SimpleStatementLine` wrapper cases; support `Subscript` (alias.output[0]) and plain attribute (alias.output); avoid altering unrelated expressions; preserve wrapper vs bare assert statement shapes.
+   - Tests (unit): `tests/unit/test_assert_transformer_alias_body_rewrites.py`
+     - test_rewrite_len_alias_output: inside With body `assert len(log.output) == 2` -> `assert len(caplog.records) == 2`.
+     - test_rewrite_membership_alias_output_subscript: `assert 'msg' in log.output[0]` -> `assert 'msg' in caplog.records[0].getMessage()`.
+     - test_rewrite_equality_alias_output: `assert caplog.records[0] == 'msg'` -> `assert caplog.records[0].getMessage() == 'msg'`.
+
+7) rewrite_following_statements_for_alias(statements: list[cst.BaseStatement], alias_name: str, start_index: int, look_ahead: int = 12) -> None
+   - Responsibility: After transforming a With that had an alias, look ahead up to `look_ahead` statements and rewrite patterns referencing the alias into caplog variants (same logic as `rewrite_asserts_using_alias_in_with_body` but on later statements). This keeps parity with existing look-ahead behavior.
+   - Inputs/Outputs: modifies `statements` in-place.
+   - Edge cases: bounds-checking, stop early when no matches; keep same look-ahead limit default 12.
+   - Tests (unit): `tests/unit/test_assert_transformer_alias_lookahead.py` (existing) plus:
+     - test_lookahead_rewrites_len_and_membership: after a With with `as log`, assert statements 3 lines later referencing `log.output` are rewritten.
+
+8) rewrite_assert_stmt_for_alias(node: cst.BaseStatement, alias_name: str) -> cst.BaseStatement | None
+   - Responsibility: Helper that rewrites a *single* statement (Assert or SimpleStatementLine wrapping an Assert or self.assert* call) if it references the alias, returning the rewritten statement or None.
+   - Tests (unit): covered by tests for (6) and (7). Add specific tests for Single-statement transforms.
+
+9) small internal helpers: _rewrite_eq_node(node: cst.CSTNode, alias_name: str) -> cst.CSTNode | None
+   - Responsibility: Shared logic used by alias-rewrite helpers that maps attribute/subscript forms referencing `alias.output` to caplog equivalents and optionally `getMessage()` wrappers for equality membership contexts.
+   - Tests (unit): small targeted tests used by other unit tests.
+
+Integration tests (end-to-end)
+--------------------------------
+- Existing tests in `tests/unit/test_assert_transformer_*` already cover many scenarios; we will add/adjust tests as we extract helpers to assert behavior remains unchanged.
+- Add two integration tests to ensure the full `wrap_assert_in_block` behavior remains identical after refactor:
+  - `tests/integration/test_assert_logs_wrap_and_alias_rewrite.py`:
+    - sample input with `self.assertLogs(...)
+      with ... as log:` and following statements that reference `log.output`. Verify the resulting AST/code matches expected output using the existing transformer pipeline.
+  - `tests/integration/test_assert_raises_and_warns_with_items.py`:
+    - input with `with self.assertRaises(E) as cm:` and `with self.assertWarns(Warn):` forms to verify proper pytest conversions and alias preservation semantics.
+
+Order of implementation (incremental, each followed by tests):
+1. Implement `_get_self_attr_call` and `_build_with_item_from_assert_call` (done).
+2. Implement `_create_with_wrapping_next_stmt` and refactor top-level bare-expression branch to call it (small change).
+3. Add unit tests for helpers in step 1 & 2 and run test subset.
+4. Extract `transform_with_items` from `elif isinstance(stmt, cst.With):` block. Add tests for `assertLogs`/`assertRaises` conversions and alias detection.
+5. Extract `rewrite_asserts_using_alias_in_with_body` and `rewrite_assert_stmt_for_alias` and unit tests for alias rewrites.
+6. Extract `rewrite_following_statements_for_alias` and confirm look-ahead tests pass.
+7. Replace in-place logic in `wrap_assert_in_block` by orchestrating calls to these helpers; run full test suite.
+
+Acceptance criteria
+- Each helper has at least one focused unit test covering the happy path and one edge-case.
+- After each extraction step, run the test suite and ensure no regressions.
+- Preserve existing conservative try/except fallback behavior where present.
+
+If you approve this detailed plan, I'll proceed to implement step 2 (`_create_with_wrapping_next_stmt` and refactor the bare-expression branch to use it), add the helper unit tests, and run the tests. Otherwise tell me which helper to implement next.
+
+- [ ] Replace the inline logic for handling bare expression `self.assert*` calls in `wrap_assert_in_block` with calls to the new helpers.
+  - [ ] Run unit tests; fix any regressions.
+
+- [ ] Extract `transform_with_items` and related alias-body rewrite logic into helpers, preserving exception-safety.
+  - [ ] Add tests for With-item rewriting and alias rewriting.
+
+- [ ] Replace the in-place look-ahead rewrite code with `rewrite_following_statements_for_alias` and verify behavior with tests.
+
+- [ ] Run full test suite and linters (ruff/mypy) and fix issues.
+
+- [ ] Final tidy: docstrings, type annotations, small refactor commit messages, open PR on `chore/simplificaton` branch.
+
+Notes / Acceptance criteria:
+- Preserve current runtime behavior for supported patterns (standalone assert calls, With-item conversion, alias rewrite patterns).
+- Keep conservative try/except fallbacks where the original code did so.
+- Maintain existing test expectations (caplog alias removal, `pytest.raises` alias preservation, default caplog level fallback to "INFO").
+
+If you'd like, I'll continue and extract the next logical chunk: replace the `bare expression` handling in `wrap_assert_in_block` to call these new helpers and add unit tests. Otherwise I can stop here and await guidance.

--- a/docs/research/research-2025-09-28-rewrite-invariants.md
+++ b/docs/research/research-2025-09-28-rewrite-invariants.md
@@ -1,0 +1,44 @@
+Rewrite invariants and parser shapes
+=====================================
+
+Date: 2025-09-28
+
+Purpose
+-------
+
+Brief developer note describing the invariants we follow when rewriting
+assertions that reference an alias-bound log-like object (for example
+``log.output``) to pytest ``caplog`` equivalents.
+
+Invariants
+----------
+
+- Conservative rewrites only: if we cannot conclusively identify or
+  safely transform a node, we return ``None`` and leave the original
+  code unchanged.
+- Only rewrite expressions that reference the provided alias name when
+  the shape is recognized (``Comparison``, membership ``In``, ``len``
+  checks, equality comparisons, etc.).
+- Walk into and rewrite the following CST shapes where appropriate:
+  - ``ParenthesizedExpression`` wrapping a ``Comparison``
+  - ``UnaryOperation`` (``not``) whose ``expression`` is one of the
+    handled shapes
+  - ``BooleanOperation`` combining comparisons (``and``/``or``)
+- When rewriting membership checks (``'err' in log.output[0]``) we map
+  the sequence of attribute/subscript accesses to ``caplog.records[...]``
+  and call ``.getMessage()`` on the resulting record expression.
+
+Why these invariants?
+---------------------
+They keep automated transformations safe across a wide range of input
+styles while minimizing false-positives. The parser/AST can represent
+semantically-equivalent source using different CST shapes; the policy
+above ensures we only transform when the mapping to ``caplog`` is
+unambiguous.
+
+Notes for future contributors
+-----------------------------
+- Prefer adding small, focused unit tests for any new rewrite shape.
+- If you consider adding a more aggressive best-effort rewrite, add a
+  flag or explicit opt-in so transformations remain auditable.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ dev = [
     "mypy>=1.0.0",
     "ruff>=0.1.0",
     "pre-commit>=3.0.0",
-    "hypothesis>=6.0.0",
     "black>=23.0.0",
     "isort>=5.12.0",
 ]

--- a/splurge_unittest_to_pytest/cli.py
+++ b/splurge_unittest_to_pytest/cli.py
@@ -67,13 +67,9 @@ def create_config(
     recurse_directories: bool = True,
     preserve_structure: bool = True,
     backup_originals: bool = True,
-    merge_setup_teardown: bool = True,
-    format_code: bool = True,
-    fixture_scope: str | None = None,
     line_length: int | None = 120,
     dry_run: bool = False,
     fail_fast: bool = False,
-    parallel_processing: bool = True,
     verbose: bool = False,
     generate_report: bool = True,
     report_format: str = "json",
@@ -103,26 +99,12 @@ def create_config(
     Returns:
         Configured MigrationConfig instance
     """
-    from .context import FixtureScope
     from .helpers.utility import sanitize_extension, sanitize_suffix
 
     suffix = sanitize_suffix(suffix)
     ext = sanitize_extension(ext)
 
     base = MigrationConfig()
-
-    # Normalize fixture_scope if provided (accept strings like "function")
-    fs = base.fixture_scope
-    if fixture_scope is not None:
-        try:
-            if isinstance(fixture_scope, str):
-                fs = FixtureScope(fixture_scope)
-            elif isinstance(fixture_scope, FixtureScope):
-                fs = fixture_scope
-            else:
-                fs = FixtureScope(str(fixture_scope))
-        except Exception:
-            fs = base.fixture_scope
 
     return MigrationConfig(
         target_directory=target_directory,
@@ -131,17 +113,13 @@ def create_config(
         recurse_directories=recurse_directories,
         preserve_structure=preserve_structure,
         backup_originals=backup_originals,
-        convert_classes_to_functions=base.convert_classes_to_functions,
-        merge_setup_teardown=merge_setup_teardown,
-        generate_fixtures=base.generate_fixtures,
-        fixture_scope=fs,
-        format_code=True,  # formatting is mandatory
-        optimize_imports=base.optimize_imports,
-        add_type_hints=base.add_type_hints,
+        # Legacy transformation flags are intentionally not exposed via the CLI.
+        # Keep the MigrationConfig minimal here and let defaults apply.
+        # Legacy flags are intentionally not exposed in the CLI and default
+        # behavior is used. Keep config minimal here.
         line_length=line_length,
         dry_run=dry_run,
         fail_fast=fail_fast,
-        parallel_processing=parallel_processing,
         verbose=verbose,
         generate_report=generate_report,
         report_format=report_format,
@@ -310,8 +288,6 @@ def migrate(
             recurse_directories=recurse,
             preserve_structure=preserve_structure,
             backup_originals=backup_originals,
-            merge_setup_teardown=merge_setup_teardown,
-            format_code=True,
             line_length=line_length,
             dry_run=dry_run,
             fail_fast=fail_fast,
@@ -475,28 +451,22 @@ def init_config(output_file: str = typer.Argument("unittest-to-pytest.yaml", hel
         "# This file contains configuration options for the migration tool.": None,
         "# You can override these settings using command-line flags.": None,
         "# Output settings": None,
-        "target_directory": default_config["target_directory"],
-        "preserve_structure": default_config["preserve_structure"],
-        "backup_originals": default_config["backup_originals"],
+        "target_directory": default_config.get("target_directory"),
+        "preserve_structure": default_config.get("preserve_structure"),
+        "backup_originals": default_config.get("backup_originals"),
         "# Transformation settings": None,
-        "convert_classes_to_functions": default_config["convert_classes_to_functions"],
-        "merge_setup_teardown": default_config["merge_setup_teardown"],
-        "generate_fixtures": default_config["generate_fixtures"],
-        "fixture_scope": default_config["fixture_scope"],
+        # Legacy/removed transformation settings intentionally omitted
         "# Code quality settings": None,
-        "format_code": default_config["format_code"],
-        "optimize_imports": default_config["optimize_imports"],
-        "add_type_hints": default_config["add_type_hints"],
-        "line_length": default_config["line_length"],
+        # Code quality settings: only include supported options
+        "line_length": default_config.get("line_length"),
         "# Behavior settings": None,
-        "dry_run": default_config["dry_run"],
-        "fail_fast": default_config["fail_fast"],
-        "parallel_processing": default_config["parallel_processing"],
+        "dry_run": default_config.get("dry_run"),
+        "fail_fast": default_config.get("fail_fast"),
         # Note: worker count configuration removed from CLI surface
         "# Reporting settings": None,
-        "verbose": default_config["verbose"],
-        "generate_report": default_config["generate_report"],
-        "report_format": default_config["report_format"],
+        "verbose": default_config.get("verbose"),
+        "generate_report": default_config.get("generate_report"),
+        "report_format": default_config.get("report_format"),
     }
 
     try:

--- a/splurge_unittest_to_pytest/context.py
+++ b/splurge_unittest_to_pytest/context.py
@@ -66,21 +66,17 @@ class MigrationConfig:
     target_extension: str | None = None
 
     # Transformation settings
-    convert_classes_to_functions: bool = True
-    merge_setup_teardown: bool = True
-    generate_fixtures: bool = True
-    fixture_scope: FixtureScope = FixtureScope.FUNCTION
+    # Legacy transformation flags removed: convert_classes_to_functions,
+    # merge_setup_teardown, generate_fixtures, fixture_scope
 
     # Code quality settings
-    format_code: bool = True
-    optimize_imports: bool = True
-    add_type_hints: bool = False
+    # Code quality flags removed: format_code, optimize_imports, add_type_hints
     line_length: int | None = 120  # Use black default (120) if None
 
     # Behavior settings
     dry_run: bool = False
     fail_fast: bool = False
-    parallel_processing: bool = True
+    # parallel_processing removed; library no longer exposes parallelism flag
     # Optional transforms
     parametrize: bool = False
 
@@ -113,12 +109,11 @@ class MigrationConfig:
         Returns:
             New MigrationConfig instance
         """
-        # Handle enum conversions
-        if "fixture_scope" in config_dict and isinstance(config_dict["fixture_scope"], str):
-            config_dict["fixture_scope"] = FixtureScope(config_dict["fixture_scope"])
-        # NOTE: legacy key handling removed: MigrationConfig has no DryRunMode
-
-        return cls(**config_dict)
+        # NOTE: legacy keys for removed flags are silently ignored. This allows
+        # loading older configuration files without failing when they still
+        # contain retired options.
+        filtered = {k: v for k, v in config_dict.items() if k in cls.__dataclass_fields__}
+        return cls(**filtered)
 
     def to_dict(self) -> dict[str, Any]:
         """Convert config to dictionary.
@@ -234,7 +229,10 @@ class PipelineContext:
         Returns:
             True if code formatting is enabled
         """
-        return self.config.format_code
+        # Code formatting flags were removed; derive from configuration
+        # presence of a line_length or default policy. If the config has an
+        # explicit 'format_code' attribute (for backward compatibility), use it.
+        return bool(getattr(self.config, "format_code", True))
 
     def get_line_length(self) -> int:
         """Get configured line length.

--- a/splurge_unittest_to_pytest/context.py
+++ b/splurge_unittest_to_pytest/context.py
@@ -321,9 +321,6 @@ class ContextManager:
         """
         issues = []
 
-        # Note: parallelism control is deprecated at the CLI surface;
-        # keep parallel_processing flag but do not validate worker counts here.
-
         if config.line_length and (config.line_length < 60 or config.line_length > 200):
             issues.append("line_length must be between 60 and 200")
 

--- a/splurge_unittest_to_pytest/steps/format_steps.py
+++ b/splurge_unittest_to_pytest/steps/format_steps.py
@@ -13,8 +13,8 @@ class FormatCodeStep(Step[str, str]):
 
     def execute(self, context: PipelineContext, code: str) -> Result[str]:
         """Format code using isort and black programmatic APIs."""
-        if not context.config.format_code:
-            return Result.success(code)
+        # Formatting is always applied by the pipeline; the legacy
+        # `format_code` flag has been removed. Proceed to format.
 
         try:
             # Apply isort for import sorting

--- a/splurge_unittest_to_pytest/transformers/assert_transformer.py
+++ b/splurge_unittest_to_pytest/transformers/assert_transformer.py
@@ -318,7 +318,9 @@ def build_with_item_from_assert_call(call_expr: cst.Call) -> cst.WithItem | None
     return None
 
 
-def create_with_wrapping_next_stmt(with_item: cst.WithItem, next_stmt: cst.BaseStatement | None) -> tuple[cst.With, int]:
+def create_with_wrapping_next_stmt(
+    with_item: cst.WithItem, next_stmt: cst.BaseStatement | None
+) -> tuple[cst.With, int]:
     """Create a `With` node that uses `with_item` and wraps `next_stmt`.
 
     Returns a tuple (with_node, consumed_count) where consumed_count is 2
@@ -416,11 +418,7 @@ def transform_with_items(stmt: cst.With) -> tuple[cst.With, str | None, bool]:
     alias_name = None
     for item in stmt.items:
         try:
-            if (
-                item.asname
-                and isinstance(item.asname, cst.AsName)
-                and isinstance(item.asname.name, cst.Name)
-            ):
+            if item.asname and isinstance(item.asname, cst.AsName) and isinstance(item.asname.name, cst.Name):
                 alias_name = item.asname.name.value
                 break
         except Exception:
@@ -493,13 +491,19 @@ def rewrite_asserts_using_alias_in_with_body(new_with: cst.With, alias_name: str
                                     sub0 = cast(cst.Subscript, arg0)
                                     if sub0.slice:
                                         new_arg = cst.Subscript(
-                                            value=cst.Attribute(value=cst.Name(value="caplog"), attr=cst.Name(value="records")),
+                                            value=cst.Attribute(
+                                                value=cst.Name(value="caplog"), attr=cst.Name(value="records")
+                                            ),
                                             slice=sub0.slice,
                                         )
                                     else:
-                                        new_arg = cst.Attribute(value=cst.Name(value="caplog"), attr=cst.Name(value="records"))
+                                        new_arg = cst.Attribute(
+                                            value=cst.Name(value="caplog"), attr=cst.Name(value="records")
+                                        )
                                 else:
-                                    new_arg = cst.Attribute(value=cst.Name(value="caplog"), attr=cst.Name(value="records"))
+                                    new_arg = cst.Attribute(
+                                        value=cst.Name(value="caplog"), attr=cst.Name(value="records")
+                                    )
                                 new_left = left.with_changes(args=[cst.Arg(value=new_arg)])
                                 new_comp = t.with_changes(left=new_left)
                                 new_assert = target_assert.with_changes(test=new_comp)
@@ -530,15 +534,25 @@ def rewrite_asserts_using_alias_in_with_body(new_with: cst.With, alias_name: str
                                     comp_sub = cast(cst.Subscript, comparator)
                                     if comp_sub.slice:
                                         new_sub = cst.Subscript(
-                                            value=cst.Attribute(value=cst.Name(value="caplog"), attr=cst.Name(value="records")),
+                                            value=cst.Attribute(
+                                                value=cst.Name(value="caplog"), attr=cst.Name(value="records")
+                                            ),
                                             slice=comp_sub.slice,
                                         )
                                     else:
-                                        new_sub = cst.Attribute(value=cst.Name(value="caplog"), attr=cst.Name(value="records"))
+                                        new_sub = cst.Attribute(
+                                            value=cst.Name(value="caplog"), attr=cst.Name(value="records")
+                                        )
                                 else:
-                                    new_sub = cst.Attribute(value=cst.Name(value="caplog"), attr=cst.Name(value="records"))
-                                getmsg = cst.Call(func=cst.Attribute(value=new_sub, attr=cst.Name(value="getMessage")), args=[])
-                                new_comp = t.with_changes(comparisons=[cst.ComparisonTarget(operator=comp.operator, comparator=getmsg)])
+                                    new_sub = cst.Attribute(
+                                        value=cst.Name(value="caplog"), attr=cst.Name(value="records")
+                                    )
+                                getmsg = cst.Call(
+                                    func=cst.Attribute(value=new_sub, attr=cst.Name(value="getMessage")), args=[]
+                                )
+                                new_comp = t.with_changes(
+                                    comparisons=[cst.ComparisonTarget(operator=comp.operator, comparator=getmsg)]
+                                )
                                 new_assert = target_assert.with_changes(test=new_comp)
                                 if wrapper_stmt is not None:
                                     s = wrapper_stmt.with_changes(body=[new_assert])
@@ -551,11 +565,7 @@ def rewrite_asserts_using_alias_in_with_body(new_with: cst.With, alias_name: str
             # Additionally handle SimpleStatementLine wrapping a self.assert* call
             if not replaced:
                 try:
-                    if (
-                        isinstance(s, cst.SimpleStatementLine)
-                        and len(s.body) == 1
-                        and isinstance(s.body[0], cst.Expr)
-                    ):
+                    if isinstance(s, cst.SimpleStatementLine) and len(s.body) == 1 and isinstance(s.body[0], cst.Expr):
                         call_expr = s.body[0].value
                         if isinstance(call_expr, cst.Call) and isinstance(call_expr.func, cst.Attribute):
                             func = call_expr.func
@@ -572,7 +582,9 @@ def rewrite_asserts_using_alias_in_with_body(new_with: cst.With, alias_name: str
                                     ):
                                         if left_arg.args:
                                             arg0 = left_arg.args[0].value
-                                            if isinstance(arg0, cst.Subscript) and isinstance(arg0.value, cst.Attribute):
+                                            if isinstance(arg0, cst.Subscript) and isinstance(
+                                                arg0.value, cst.Attribute
+                                            ):
                                                 attr = arg0.value
                                                 if (
                                                     isinstance(attr.value, cst.Name)
@@ -582,13 +594,26 @@ def rewrite_asserts_using_alias_in_with_body(new_with: cst.With, alias_name: str
                                                 ):
                                                     if arg0.slice:
                                                         new_arg = cst.Subscript(
-                                                            value=cst.Attribute(value=cst.Name(value="caplog"), attr=cst.Name(value="records")),
+                                                            value=cst.Attribute(
+                                                                value=cst.Name(value="caplog"),
+                                                                attr=cst.Name(value="records"),
+                                                            ),
                                                             slice=arg0.slice,
                                                         )
                                                     else:
-                                                        new_arg = cst.Attribute(value=cst.Name(value="caplog"), attr=cst.Name(value="records"))
+                                                        new_arg = cst.Attribute(
+                                                            value=cst.Name(value="caplog"),
+                                                            attr=cst.Name(value="records"),
+                                                        )
                                                     new_left = left_arg.with_changes(args=[cst.Arg(value=new_arg)])
-                                                    comp = cst.Comparison(left=new_left, comparisons=[cst.ComparisonTarget(operator=cst.Equal(), comparator=right_arg)])
+                                                    comp = cst.Comparison(
+                                                        left=new_left,
+                                                        comparisons=[
+                                                            cst.ComparisonTarget(
+                                                                operator=cst.Equal(), comparator=right_arg
+                                                            )
+                                                        ],
+                                                    )
                                                     new_assert = cst.Assert(test=comp)
                                                     s = cst.SimpleStatementLine(body=[new_assert])
                                                     replaced = True
@@ -597,7 +622,9 @@ def rewrite_asserts_using_alias_in_with_body(new_with: cst.With, alias_name: str
                                 if mname == "assertIn" and len(call_expr.args) >= 2:
                                     member = call_expr.args[0].value
                                     container = call_expr.args[1].value
-                                    if isinstance(container, cst.Subscript) and isinstance(container.value, cst.Attribute):
+                                    if isinstance(container, cst.Subscript) and isinstance(
+                                        container.value, cst.Attribute
+                                    ):
                                         attr = container.value
                                         if (
                                             isinstance(attr.value, cst.Name)
@@ -606,11 +633,21 @@ def rewrite_asserts_using_alias_in_with_body(new_with: cst.With, alias_name: str
                                             and attr.attr.value == "output"
                                         ):
                                             new_sub = cst.Subscript(
-                                                value=cst.Attribute(value=cst.Name(value="caplog"), attr=cst.Name(value="records")),
+                                                value=cst.Attribute(
+                                                    value=cst.Name(value="caplog"), attr=cst.Name(value="records")
+                                                ),
                                                 slice=container.slice,
                                             )
-                                            getmsg = cst.Call(func=cst.Attribute(value=new_sub, attr=cst.Name(value="getMessage")), args=[])
-                                            new_comp = cst.Comparison(left=member, comparisons=[cst.ComparisonTarget(operator=cst.In(), comparator=getmsg)])
+                                            getmsg = cst.Call(
+                                                func=cst.Attribute(value=new_sub, attr=cst.Name(value="getMessage")),
+                                                args=[],
+                                            )
+                                            new_comp = cst.Comparison(
+                                                left=member,
+                                                comparisons=[
+                                                    cst.ComparisonTarget(operator=cst.In(), comparator=getmsg)
+                                                ],
+                                            )
                                             new_assert = cst.Assert(test=new_comp)
                                             s = cst.SimpleStatementLine(body=[new_assert])
                                             replaced = True
@@ -626,7 +663,9 @@ def rewrite_asserts_using_alias_in_with_body(new_with: cst.With, alias_name: str
         return new_with
 
 
-def rewrite_following_statements_for_alias(statements: list[cst.BaseStatement], start_index: int, alias_name: str) -> None:
+def rewrite_following_statements_for_alias(
+    statements: list[cst.BaseStatement], start_index: int, alias_name: str
+) -> None:
     """Look ahead from start_index and rewrite common patterns that reference alias.output.
 
     Mutates `statements` in place.
@@ -651,9 +690,7 @@ def rewrite_following_statements_for_alias(statements: list[cst.BaseStatement], 
             if isinstance(t, cst.Comparison):
                 left = t.left
                 if (
-                    isinstance(left, cst.Call)
-                    and isinstance(left.func, cst.Name)
-                    and left.func.value == "len"
+                    isinstance(left, cst.Call) and isinstance(left.func, cst.Name) and left.func.value == "len"
                 ) and left.args:
                     arg0 = left.args[0].value
                     if isinstance(arg0, cst.Subscript) and isinstance(arg0.value, cst.Attribute):
@@ -673,7 +710,10 @@ def rewrite_following_statements_for_alias(statements: list[cst.BaseStatement], 
                             and attr.attr.value == "output"
                         ):
                             if arg0.slice:
-                                new_arg = cst.Subscript(value=cst.Attribute(value=cst.Name(value="caplog"), attr=cst.Name(value="records")), slice=arg0.slice)
+                                new_arg = cst.Subscript(
+                                    value=cst.Attribute(value=cst.Name(value="caplog"), attr=cst.Name(value="records")),
+                                    slice=arg0.slice,
+                                )
                             else:
                                 new_arg = cst.Attribute(value=cst.Name(value="caplog"), attr=cst.Name(value="records"))
                             new_left = left.with_changes(args=[cst.Arg(value=new_arg)])
@@ -703,11 +743,16 @@ def rewrite_following_statements_for_alias(statements: list[cst.BaseStatement], 
                         and comp_attr.attr.value == "output"
                     ):
                         if isinstance(comparator, cst.Subscript) and comparator.slice:
-                            new_sub = cst.Subscript(value=cst.Attribute(value=cst.Name(value="caplog"), attr=cst.Name(value="records")), slice=comparator.slice)
+                            new_sub = cst.Subscript(
+                                value=cst.Attribute(value=cst.Name(value="caplog"), attr=cst.Name(value="records")),
+                                slice=comparator.slice,
+                            )
                         else:
                             new_sub = cst.Attribute(value=cst.Name(value="caplog"), attr=cst.Name(value="records"))
                         getmsg = cst.Call(func=cst.Attribute(value=new_sub, attr=cst.Name(value="getMessage")), args=[])
-                        new_comp = t.with_changes(comparisons=[cst.ComparisonTarget(operator=comp.operator, comparator=getmsg)])
+                        new_comp = t.with_changes(
+                            comparisons=[cst.ComparisonTarget(operator=comp.operator, comparator=getmsg)]
+                        )
                         new_assert = target_assert.with_changes(test=new_comp)
                         if wrapper_stmt is not None:
                             statements[k] = wrapper_stmt.with_changes(body=[new_assert])
@@ -717,6 +762,7 @@ def rewrite_following_statements_for_alias(statements: list[cst.BaseStatement], 
 
             # equality comparisons: caplog.records[0] == 'msg' or alias.output[0] == 'msg'
             if isinstance(t, cst.Comparison):
+
                 def _rewrite_eq(node: cst.CSTNode, _alias_name=alias_name) -> cst.CSTNode | None:
                     if isinstance(node, cst.Subscript) and isinstance(node.value, cst.Attribute):
                         attr = node.value
@@ -726,8 +772,13 @@ def rewrite_following_statements_for_alias(statements: list[cst.BaseStatement], 
                             and isinstance(attr.attr, cst.Name)
                             and attr.attr.value == "output"
                         ):
-                            new_sub = cst.Subscript(value=cst.Attribute(value=cst.Name(value="caplog"), attr=cst.Name(value="records")), slice=node.slice)
-                            return cst.Call(func=cst.Attribute(value=new_sub, attr=cst.Name(value="getMessage")), args=[])
+                            new_sub = cst.Subscript(
+                                value=cst.Attribute(value=cst.Name(value="caplog"), attr=cst.Name(value="records")),
+                                slice=node.slice,
+                            )
+                            return cst.Call(
+                                func=cst.Attribute(value=new_sub, attr=cst.Name(value="getMessage")), args=[]
+                            )
                     if (
                         isinstance(node, cst.Attribute)
                         and isinstance(node.value, cst.Name)

--- a/splurge_unittest_to_pytest/transformers/assert_transformer.py
+++ b/splurge_unittest_to_pytest/transformers/assert_transformer.py
@@ -242,7 +242,7 @@ def transform_assert_raises_regex(node: cst.Call) -> cst.CSTNode:
     return node
 
 
-def _get_self_attr_call(stmt: cst.BaseStatement) -> tuple[str, cst.Call] | None:
+def get_self_attr_call(stmt: cst.BaseStatement) -> tuple[str, cst.Call] | None:
     """If `stmt` is a bare expression like `self.foo(...)` or `cls.foo(...)`,
     return (attr_name, call_expr). Otherwise return None.
     """
@@ -255,7 +255,7 @@ def _get_self_attr_call(stmt: cst.BaseStatement) -> tuple[str, cst.Call] | None:
     return None
 
 
-def _build_with_item_from_assert_call(call_expr: cst.Call) -> cst.WithItem | None:
+def build_with_item_from_assert_call(call_expr: cst.Call) -> cst.WithItem | None:
     """Given a Call node whose func is a `self`/`cls` attribute, build
     a corresponding pytest WithItem for known assert context managers.
 
@@ -318,7 +318,7 @@ def _build_with_item_from_assert_call(call_expr: cst.Call) -> cst.WithItem | Non
     return None
 
 
-def _create_with_wrapping_next_stmt(with_item: cst.WithItem, next_stmt: cst.BaseStatement | None) -> tuple[cst.With, int]:
+def create_with_wrapping_next_stmt(with_item: cst.WithItem, next_stmt: cst.BaseStatement | None) -> tuple[cst.With, int]:
     """Create a `With` node that uses `with_item` and wraps `next_stmt`.
 
     Returns a tuple (with_node, consumed_count) where consumed_count is 2

--- a/splurge_unittest_to_pytest/transformers/assert_transformer.py
+++ b/splurge_unittest_to_pytest/transformers/assert_transformer.py
@@ -242,7 +242,7 @@ def transform_assert_raises_regex(node: cst.Call) -> cst.CSTNode:
     return node
 
 
-def wrap_assert_logs_in_block(statements: list[cst.BaseStatement]) -> list[cst.BaseStatement]:
+def wrap_assert_in_block(statements: list[cst.BaseStatement]) -> list[cst.BaseStatement]:
     """Wrap `self.assertLogs`/`self.assertNoLogs` calls followed by a statement into a With block.
 
     This mirrors the previous in-transformer behavior moved here so it can be reused

--- a/splurge_unittest_to_pytest/transformers/unittest_transformer.py
+++ b/splurge_unittest_to_pytest/transformers/unittest_transformer.py
@@ -46,7 +46,7 @@ from .assert_transformer import (
     transform_caplog_alias_string_fallback,
     transform_fail,
     transform_skip_test,
-    wrap_assert_logs_in_block,
+    wrap_assert_in_block,
 )
 from .fixture_transformer import (
     create_class_fixture,
@@ -395,7 +395,7 @@ class UnittestToPytestCstTransformer(cst.CSTTransformer):
         # so top-level logging assertions are preserved structurally.
         try:
             # Only call if helper is available
-            final_body = wrap_assert_logs_in_block(list(final_body))  # type: ignore[arg-type]
+            final_body = wrap_assert_in_block(list(final_body))  # type: ignore[arg-type]
         except Exception:
             # Be conservative: if rewrite fails, keep original final_body
             pass
@@ -430,7 +430,7 @@ class UnittestToPytestCstTransformer(cst.CSTTransformer):
                 updated_node = ensure_subtests_param(updated_node)
 
             # Then wrap assertLogs/assertNoLogs patterns using shared helper
-            new_body = wrap_assert_logs_in_block(body_with_subtests)
+            new_body = wrap_assert_in_block(body_with_subtests)
             result_node = updated_node.with_changes(body=updated_node.body.with_changes(body=new_body))
         except Exception:
             result_node = updated_node

--- a/tests/integration/test_data_driven_final.py
+++ b/tests/integration/test_data_driven_final.py
@@ -86,7 +86,7 @@ class TestDataDrivenTransformation:
             output_file = tmp_path / f"test_{test_num}_output.py"
 
             # Create configuration for initial pipeline run (use tmp_path as output dir)
-            config = create_config(format_code=False, dry_run=False, target_directory=str(tmp_path))
+            config = create_config(dry_run=False, target_directory=str(tmp_path))
 
             # Create event bus
             event_bus = create_event_bus()

--- a/tests/integration/test_modular_architecture.py
+++ b/tests/integration/test_modular_architecture.py
@@ -24,7 +24,6 @@ def test_modular_architecture():
     # Test basic config creation
     config = MigrationConfig()
     assert config.line_length == 120
-    assert config.format_code is True
     assert config.backup_originals is True
 
     assert True  # Mark test as successful

--- a/tests/unit/test_assert_transformer_build_caplog.py
+++ b/tests/unit/test_assert_transformer_build_caplog.py
@@ -1,0 +1,15 @@
+import libcst as cst
+
+from splurge_unittest_to_pytest.transformers.assert_transformer import build_caplog_call
+
+
+def test_build_caplog_call_defaults_to_info():
+    call = cst.parse_expression("self.assertLogs('x')")
+    assert isinstance(call, cst.Call)
+    cap_call = build_caplog_call(call)
+    assert isinstance(cap_call, cst.Call)
+    assert isinstance(cap_call.func, cst.Attribute)
+    assert cap_call.func.attr.value == "at_level"
+    assert len(cap_call.args) == 1
+    assert isinstance(cap_call.args[0].value, cst.SimpleString)
+    assert cap_call.args[0].value.value == '"INFO"'

--- a/tests/unit/test_assert_transformer_caplog_helper.py
+++ b/tests/unit/test_assert_transformer_caplog_helper.py
@@ -1,0 +1,28 @@
+import libcst as cst
+
+from splurge_unittest_to_pytest.transformers.assert_transformer import (
+    get_caplog_level_args,
+    transform_with_items,
+)
+
+
+def test_transform_with_items_uses_default_info_for_caplog():
+    module = cst.parse_module(
+        """
+with self.assertLogs('x'):
+    pass
+"""
+    )
+    original_with = module.body[0]
+    assert isinstance(original_with, cst.With)
+    new_with, alias_name, changed = transform_with_items(original_with)
+    assert changed is True
+    # ensure the new With contains a caplog.at_level call with a SimpleString '"INFO"'
+    item = new_with.items[0]
+    assert isinstance(item.item, cst.Call)
+    assert isinstance(item.item.func, cst.Attribute)
+    assert item.item.func.attr.value == "at_level"
+    assert len(item.item.args) == 1
+    arg = item.item.args[0]
+    assert isinstance(arg.value, cst.SimpleString)
+    assert arg.value.value == '"INFO"'

--- a/tests/unit/test_assert_transformer_create_with.py
+++ b/tests/unit/test_assert_transformer_create_with.py
@@ -1,0 +1,42 @@
+import libcst as cst
+
+from splurge_unittest_to_pytest.transformers.assert_transformer import (
+    build_with_item_from_assert_call,
+    create_with_wrapping_next_stmt,
+)
+
+
+def test_create_with_wrapping_next_stmt_with_next_statement():
+    call = cst.parse_expression("self.assertLogs('x')")
+    assert isinstance(call, cst.Call)
+    wi = build_with_item_from_assert_call(call)
+    assert wi is not None
+
+    next_stmt = cst.parse_statement("print('hi')")
+    with_node, consumed = create_with_wrapping_next_stmt(wi, next_stmt)
+    assert consumed == 2
+    assert isinstance(with_node, cst.With)
+    # body should include the next_stmt (not nested With)
+    body = with_node.body
+    assert hasattr(body, "body")
+    assert len(body.body) == 1
+    assert isinstance(body.body[0], cst.SimpleStatementLine)
+
+
+def test_create_with_wrapping_next_stmt_without_next_statement():
+    call = cst.parse_expression("self.assertLogs('x')")
+    assert isinstance(call, cst.Call)
+    wi = build_with_item_from_assert_call(call)
+    assert wi is not None
+
+    with_node, consumed = create_with_wrapping_next_stmt(wi, None)
+    assert consumed == 1
+    assert isinstance(with_node, cst.With)
+    # body should contain a pass statement
+    body = with_node.body
+    assert hasattr(body, "body")
+    assert len(body.body) == 1
+    stmt = body.body[0]
+    assert isinstance(stmt, cst.SimpleStatementLine)
+    assert isinstance(stmt.body[0].value, cst.Name)
+    assert stmt.body[0].value.value == "pass"

--- a/tests/unit/test_assert_transformer_cst_direct.py
+++ b/tests/unit/test_assert_transformer_cst_direct.py
@@ -1,6 +1,6 @@
 import libcst as cst
 
-from splurge_unittest_to_pytest.transformers.assert_transformer import wrap_assert_logs_in_block
+from splurge_unittest_to_pytest.transformers.assert_transformer import wrap_assert_in_block
 
 
 def _make_assert_len_on_log_output(equal_to: int, use_subscript: bool = False) -> cst.Assert:
@@ -37,7 +37,7 @@ def test_with_inner_assert_node_rewrites_attribute_and_subscript():
     inner_assert = _make_assert_len_on_log_output(2, use_subscript=False)
     with_node = cst.With(body=cst.IndentedBlock(body=[cst.SimpleStatementLine(body=[inner_assert])]), items=[with_item])
 
-    out = wrap_assert_logs_in_block([with_node])
+    out = wrap_assert_in_block([with_node])
     code = cst.Module(body=out).code
     assert "caplog.records" in code
     assert "len(caplog.records)" in code
@@ -95,7 +95,7 @@ def test_lookahead_rewrites_following_asserts_after_with():
     )
 
     stmts = [with_node, assert1, membership]
-    out = wrap_assert_logs_in_block(stmts)
+    out = wrap_assert_in_block(stmts)
     code = cst.Module(body=out).code
     assert "caplog.records" in code
     assert ".getMessage()" in code

--- a/tests/unit/test_assert_transformer_handle_bare.py
+++ b/tests/unit/test_assert_transformer_handle_bare.py
@@ -1,0 +1,44 @@
+import libcst as cst
+
+from splurge_unittest_to_pytest.transformers.assert_transformer import handle_bare_assert_call
+
+
+def _stmt(code: str):
+    module = cst.parse_module(code)
+    return module.body[0]
+
+
+def test_handle_bare_with_following_statement_wraps():
+    stmts = [
+        _stmt("self.assertLogs('x', level='INFO')"),
+        _stmt("print('hi')"),
+    ]
+
+    nodes, consumed, handled = handle_bare_assert_call(stmts, 0)
+    assert handled is True
+    assert consumed == 2
+    assert len(nodes) == 1
+    assert isinstance(nodes[0], cst.With)
+
+
+def test_handle_bare_no_following_statement_creates_pass():
+    stmts = [
+        _stmt("self.assertLogs('x')"),
+    ]
+
+    nodes, consumed, handled = handle_bare_assert_call(stmts, 0)
+    assert handled is True
+    assert consumed == 1
+    assert len(nodes) == 1
+    assert isinstance(nodes[0], cst.With)
+
+
+def test_handle_bare_non_matching_returns_false():
+    stmts = [
+        _stmt("print('no')"),
+    ]
+
+    nodes, consumed, handled = handle_bare_assert_call(stmts, 0)
+    assert handled is False
+    assert consumed == 0
+    assert nodes == []

--- a/tests/unit/test_assert_transformer_handle_bare_extra.py
+++ b/tests/unit/test_assert_transformer_handle_bare_extra.py
@@ -1,0 +1,46 @@
+import libcst as cst
+
+from splurge_unittest_to_pytest.transformers.assert_transformer import (
+    build_with_item_from_assert_call,
+    get_caplog_level_args,
+    handle_bare_assert_call,
+    transform_with_items,
+)
+
+
+def _stmt(code: str):
+    module = cst.parse_module(code)
+    return module.body[0]
+
+
+def test_get_caplog_level_args_defaults_to_info():
+    call = cst.parse_expression("self.assertLogs('x')")
+    if isinstance(call, cst.BaseExpression):
+        # call is a BaseExpression wrapper; unwrap for helper
+        call = call
+    assert isinstance(call, cst.Call)
+    args = get_caplog_level_args(call)
+    assert len(args) == 1
+    assert isinstance(args[0].value, cst.SimpleString)
+    assert args[0].value.value == '"INFO"'
+
+
+def test_pytest_raises_alias_preserved_when_existing_asname():
+    # When an existing With uses `self.assertRaises(...) as cm`, transform_with_items should
+    # preserve the `as` alias on the WithItem when converting to pytest.raises(...)
+    module = cst.parse_module(
+        """
+with self.assertRaises(ValueError) as cm:
+    _ = cm.exception
+"""
+    )
+    original_with = module.body[0]
+    assert isinstance(original_with, cst.With)
+    new_with, alias_name, changed = transform_with_items(original_with)
+    assert changed is True
+    assert alias_name == "cm"
+    # Ensure the new WithItem preserves the asname
+    new_item = new_with.items[0]
+    assert new_item.asname is not None
+    assert isinstance(new_item.asname.name, cst.Name)
+    assert new_item.asname.name.value == "cm"

--- a/tests/unit/test_assert_transformer_helpers.py
+++ b/tests/unit/test_assert_transformer_helpers.py
@@ -1,20 +1,25 @@
 import libcst as cst
 
 from splurge_unittest_to_pytest.transformers.assert_transformer import (
-    _build_with_item_from_assert_call,
-    _create_with_wrapping_next_stmt,
-    _get_self_attr_call,
+    build_with_item_from_assert_call,
+    create_with_wrapping_next_stmt,
+    get_self_attr_call,
 )
 
 
 def parse_stmt(code: str) -> cst.BaseStatement:
     module = cst.parse_module(code)
-    return module.body[0]
+    # return the first top-level simple statement
+    for node in module.body:
+        if isinstance(node, cst.SimpleStatementLine):
+            return node
+    # fallback: wrap in an expression
+    return cst.SimpleStatementLine(body=[cst.Expr(value=cst.parse_expression(code))])
 
 
 def test_get_self_attr_call_matches():
     stmt = parse_stmt("self.assertLogs('x')")
-    res = _get_self_attr_call(stmt)
+    res = get_self_attr_call(stmt)
     assert res is not None
     name, call = res
     assert name == "assertLogs"
@@ -23,16 +28,16 @@ def test_get_self_attr_call_matches():
 
 def test_get_self_attr_call_none_for_non_expr():
     stmt = parse_stmt("x = 1")
-    res = _get_self_attr_call(stmt)
+    res = get_self_attr_call(stmt)
     assert res is None
 
 
 def test_build_with_item_warns_and_match():
     stmt = parse_stmt("self.assertWarns(Exception, match='x')")
-    res = _get_self_attr_call(stmt)
+    res = get_self_attr_call(stmt)
     assert res is not None
     _, call = res
-    wi = _build_with_item_from_assert_call(call)
+    wi = build_with_item_from_assert_call(call)
     assert wi is not None
     # expect pytest.warns in the WithItem
     assert isinstance(wi.item, cst.Call)
@@ -43,10 +48,10 @@ def test_build_with_item_warns_and_match():
 
 def test_build_with_item_assertlogs_default_level():
     stmt = parse_stmt("self.assertLogs('logger')")
-    res = _get_self_attr_call(stmt)
+    res = get_self_attr_call(stmt)
     assert res is not None
     _, call = res
-    wi = _build_with_item_from_assert_call(call)
+    wi = build_with_item_from_assert_call(call)
     assert wi is not None
     assert isinstance(wi.item, cst.Call)
     func = wi.item.func
@@ -58,11 +63,12 @@ def test_create_with_wrapping_next_stmt_unwraps_and_pass():
     # when next_stmt is a normal statement
     wi = cst.WithItem(item=cst.Call(func=cst.Attribute(value=cst.Name(value="caplog"), attr=cst.Name(value="at_level")), args=[]))
     stmt = parse_stmt("x = 1")
-    wnode, consumed = _create_with_wrapping_next_stmt(wi, stmt)
+    wnode, consumed = create_with_wrapping_next_stmt(wi, stmt)
     assert consumed == 2
     assert isinstance(wnode, cst.With)
 
     # when next_stmt is None -> pass body
-    wnode2, consumed2 = _create_with_wrapping_next_stmt(wi, None)
+    wnode2, consumed2 = create_with_wrapping_next_stmt(wi, None)
     assert consumed2 == 1
     assert isinstance(wnode2, cst.With)
+

--- a/tests/unit/test_assert_transformer_helpers.py
+++ b/tests/unit/test_assert_transformer_helpers.py
@@ -61,7 +61,9 @@ def test_build_with_item_assertlogs_default_level():
 
 def test_create_with_wrapping_next_stmt_unwraps_and_pass():
     # when next_stmt is a normal statement
-    wi = cst.WithItem(item=cst.Call(func=cst.Attribute(value=cst.Name(value="caplog"), attr=cst.Name(value="at_level")), args=[]))
+    wi = cst.WithItem(
+        item=cst.Call(func=cst.Attribute(value=cst.Name(value="caplog"), attr=cst.Name(value="at_level")), args=[])
+    )
     stmt = parse_stmt("x = 1")
     wnode, consumed = create_with_wrapping_next_stmt(wi, stmt)
     assert consumed == 2
@@ -71,4 +73,3 @@ def test_create_with_wrapping_next_stmt_unwraps_and_pass():
     wnode2, consumed2 = create_with_wrapping_next_stmt(wi, None)
     assert consumed2 == 1
     assert isinstance(wnode2, cst.With)
-

--- a/tests/unit/test_assert_transformer_helpers.py
+++ b/tests/unit/test_assert_transformer_helpers.py
@@ -1,0 +1,68 @@
+import libcst as cst
+
+from splurge_unittest_to_pytest.transformers.assert_transformer import (
+    _build_with_item_from_assert_call,
+    _create_with_wrapping_next_stmt,
+    _get_self_attr_call,
+)
+
+
+def parse_stmt(code: str) -> cst.BaseStatement:
+    module = cst.parse_module(code)
+    return module.body[0]
+
+
+def test_get_self_attr_call_matches():
+    stmt = parse_stmt("self.assertLogs('x')")
+    res = _get_self_attr_call(stmt)
+    assert res is not None
+    name, call = res
+    assert name == "assertLogs"
+    assert isinstance(call, cst.Call)
+
+
+def test_get_self_attr_call_none_for_non_expr():
+    stmt = parse_stmt("x = 1")
+    res = _get_self_attr_call(stmt)
+    assert res is None
+
+
+def test_build_with_item_warns_and_match():
+    stmt = parse_stmt("self.assertWarns(Exception, match='x')")
+    res = _get_self_attr_call(stmt)
+    assert res is not None
+    _, call = res
+    wi = _build_with_item_from_assert_call(call)
+    assert wi is not None
+    # expect pytest.warns in the WithItem
+    assert isinstance(wi.item, cst.Call)
+    func = wi.item.func
+    assert isinstance(func, cst.Attribute)
+    assert func.attr.value == "warns"
+
+
+def test_build_with_item_assertlogs_default_level():
+    stmt = parse_stmt("self.assertLogs('logger')")
+    res = _get_self_attr_call(stmt)
+    assert res is not None
+    _, call = res
+    wi = _build_with_item_from_assert_call(call)
+    assert wi is not None
+    assert isinstance(wi.item, cst.Call)
+    func = wi.item.func
+    assert isinstance(func, cst.Attribute)
+    assert func.attr.value == "at_level"
+
+
+def test_create_with_wrapping_next_stmt_unwraps_and_pass():
+    # when next_stmt is a normal statement
+    wi = cst.WithItem(item=cst.Call(func=cst.Attribute(value=cst.Name(value="caplog"), attr=cst.Name(value="at_level")), args=[]))
+    stmt = parse_stmt("x = 1")
+    wnode, consumed = _create_with_wrapping_next_stmt(wi, stmt)
+    assert consumed == 2
+    assert isinstance(wnode, cst.With)
+
+    # when next_stmt is None -> pass body
+    wnode2, consumed2 = _create_with_wrapping_next_stmt(wi, None)
+    assert consumed2 == 1
+    assert isinstance(wnode2, cst.With)

--- a/tests/unit/test_assert_transformer_lookahead_rhs_and_asname.py
+++ b/tests/unit/test_assert_transformer_lookahead_rhs_and_asname.py
@@ -1,6 +1,6 @@
 import libcst as cst
 
-from splurge_unittest_to_pytest.transformers.assert_transformer import wrap_assert_logs_in_block
+from splurge_unittest_to_pytest.transformers.assert_transformer import wrap_assert_in_block
 
 
 def _with_assertlogs_as_log(inner_stmts):
@@ -25,7 +25,7 @@ def test_with_assertRaises_preserves_asname():
         asname=cst.AsName(name=cst.Name(value="e")),
     )
     w = cst.With(body=cst.IndentedBlock(body=[cst.Pass()]), items=[item])
-    out = wrap_assert_logs_in_block([w])
+    out = wrap_assert_in_block([w])
     assert len(out) == 1
     new_w = out[0]
     assert isinstance(new_w, cst.With)
@@ -49,7 +49,7 @@ def test_attribute_equality_rewritten_to_caplog_records_inside_with():
         ]
     )
 
-    out = wrap_assert_logs_in_block([with_stmt, following_assert])
+    out = wrap_assert_in_block([with_stmt, following_assert])
     code = cst.Module(body=out).code
     assert "caplog.records" in code
 
@@ -73,7 +73,7 @@ def test_rhs_attribute_lookahead_rewrite_changes_rhs_to_caplog_records():
             )
         ]
     )
-    out = wrap_assert_logs_in_block([with_stmt, s])
+    out = wrap_assert_in_block([with_stmt, s])
     code = cst.Module(body=out).code
     assert "caplog.records" in code
 
@@ -99,7 +99,7 @@ def test_rhs_subscript_getmessage_transformed_by_lookahead():
             )
         ]
     )
-    out = wrap_assert_logs_in_block([with_stmt, s])
+    out = wrap_assert_in_block([with_stmt, s])
     code = cst.Module(body=out).code
     # expecting .getMessage() inserted
     assert ".getMessage(" in code or "caplog.records" in code

--- a/tests/unit/test_assert_transformer_more_branches.py
+++ b/tests/unit/test_assert_transformer_more_branches.py
@@ -2,7 +2,7 @@ import libcst as cst
 
 from splurge_unittest_to_pytest.transformers.assert_transformer import (
     transform_caplog_alias_string_fallback,
-    wrap_assert_logs_in_block,
+    wrap_assert_in_block,
 )
 
 
@@ -16,7 +16,7 @@ def _stmt(code: str) -> cst.SimpleStatementLine:
 
 def test_assert_nologs_bare_call_uses_caplog_at_level_and_pass():
     stmt = _stmt("self.assertNoLogs('root', level='DEBUG')")
-    out = wrap_assert_logs_in_block([stmt])
+    out = wrap_assert_in_block([stmt])
     assert len(out) == 1
     w = out[0]
     assert isinstance(w, cst.With)
@@ -27,7 +27,7 @@ def test_assert_nologs_bare_call_uses_caplog_at_level_and_pass():
 
 def test_assert_warnsregex_with_match_kw_converted_to_pytest_warns():
     stmt = _stmt("self.assertWarnsRegex(ValueError, 'msg')")
-    out = wrap_assert_logs_in_block([stmt, _stmt("pass")])
+    out = wrap_assert_in_block([stmt, _stmt("pass")])
     assert isinstance(out[0], cst.With)
     w = out[0]
     # check pytest.warns and match kw present
@@ -84,7 +84,7 @@ def test_lookahead_rewrite_rewrites_following_asserts_using_alias():
     )
 
     stmts = [with_stmt, s1, s2]
-    out = wrap_assert_logs_in_block(stmts)
+    out = wrap_assert_in_block(stmts)
     # After wrapping we should have a With and the lookahead loop should have rewritten s1/s2 in-place
     assert any("caplog.records" in cst.Module(body=out).code for _ in (0,))
 

--- a/tests/unit/test_assert_transformer_ranges_specific.py
+++ b/tests/unit/test_assert_transformer_ranges_specific.py
@@ -3,7 +3,7 @@ import libcst as cst
 from splurge_unittest_to_pytest.transformers.assert_transformer import (
     transform_assert_almost_equal,
     transform_caplog_alias_string_fallback,
-    wrap_assert_logs_in_block,
+    wrap_assert_in_block,
 )
 
 
@@ -20,7 +20,7 @@ def test_wrap_assert_warns_bare_call_wraps_following_stmt():
     # covers wrap_assert_logs_in_block bare-call path (lines ~267-278)
     stmt1 = _make_simple_stmt_from_code("self.assertWarns(ValueError)")
     stmt2 = _make_simple_stmt_from_code("raise ValueError()")
-    out = wrap_assert_logs_in_block([stmt1, stmt2])
+    out = wrap_assert_in_block([stmt1, stmt2])
     assert len(out) == 1
     # expect a With wrapping the following statement
     assert isinstance(out[0], cst.With)
@@ -79,7 +79,7 @@ def test_rewrite_equality_and_membership_variants_using_alias_lookahead():
     with_stmt = cst.With(body=cst.IndentedBlock(body=[inner_assert1, inner_assert2]), items=[with_item])
 
     # run through wrap_assert_logs_in_block which handles With rewriting and lookahead
-    out = wrap_assert_logs_in_block([with_stmt])
+    out = wrap_assert_in_block([with_stmt])
     # Expect the produced With to reference caplog in inner assertions
     assert len(out) == 1
     new_with = out[0]

--- a/tests/unit/test_assert_transformer_regression_unary_boolean.py
+++ b/tests/unit/test_assert_transformer_regression_unary_boolean.py
@@ -1,0 +1,26 @@
+import libcst as cst
+
+from splurge_unittest_to_pytest.transformers.assert_transformer import (
+    rewrite_single_alias_assert,
+)
+
+
+def _parse_assert(src: str) -> cst.BaseSmallStatement:
+    mod = cst.parse_module(src)
+    stmt = mod.body[0]
+    if isinstance(stmt, cst.SimpleStatementLine) and len(stmt.body) == 1 and isinstance(stmt.body[0], cst.Assert):
+        return stmt.body[0]
+    if isinstance(stmt, cst.Assert):
+        return stmt
+    raise RuntimeError("unexpected parse")
+
+
+def test_unary_not_wrapping_boolean_and_regression():
+    # regression test: ensure unary-not around boolean-and with membership
+    # comparisons referencing alias.output is rewritten to caplog form
+    src = "assert not (('err' in log.output[0]) and ('x' in log.output[1]))"
+    a = _parse_assert(src)
+    new = rewrite_single_alias_assert(a, "log")
+    r = repr(new if new is not None else a)
+    assert "caplog" in r
+    assert "getMessage" in r or "records" in r

--- a/tests/unit/test_assert_transformer_rewrite_helpers.py
+++ b/tests/unit/test_assert_transformer_rewrite_helpers.py
@@ -3,6 +3,7 @@ import libcst as cst
 from splurge_unittest_to_pytest.transformers.assert_transformer import (
     rewrite_asserts_using_alias_in_with_body,
     rewrite_following_statements_for_alias,
+    transform_with_items,
 )
 
 
@@ -75,5 +76,65 @@ assert 'oops' in log.output[0]
     # mutate following statements in place
     rewrite_following_statements_for_alias(stmts, idx + 1, "log")
     joined = "\n".join(repr(s) for s in stmts)
+    assert "caplog" in joined
+    assert "getMessage" in joined
+
+
+def test_preserve_asname_for_raises_with_item():
+    # Build a With node representing: with self.assertRaises(ValueError) as cm: pass
+    with_item = cst.WithItem(
+        item=cst.Call(
+            func=cst.Attribute(value=cst.Name(value="self"), attr=cst.Name(value="assertRaises")),
+            args=[cst.Arg(value=cst.Name(value="ValueError"))],
+        ),
+        asname=cst.AsName(name=cst.Name(value="cm")),
+    )
+    body = cst.IndentedBlock(body=[cst.SimpleStatementLine(body=[cst.Expr(value=cst.Name(value="pass"))])])
+    w = cst.With(items=[with_item], body=body)
+
+    new_with, alias_name, changed = transform_with_items(w)
+    assert changed
+    # transformed item should call pytest.raises and preserve the asname
+    assert "pytest" in repr(new_with.items[0].item)
+    assert new_with.items[0].asname is not None
+    assert isinstance(new_with.items[0].asname.name, cst.Name)
+    assert new_with.items[0].asname.name.value == "cm"
+
+
+def test_caplog_default_level_added_when_missing():
+    # Build With node representing: with self.assertLogs("foo"):
+    with_item = cst.WithItem(
+        item=cst.Call(
+            func=cst.Attribute(value=cst.Name(value="self"), attr=cst.Name(value="assertLogs")),
+            args=[cst.Arg(value=cst.SimpleString(value='"foo"'))],
+        ),
+    )
+    body = cst.IndentedBlock(body=[cst.SimpleStatementLine(body=[cst.Expr(value=cst.Name(value="pass"))])])
+    w = cst.With(items=[with_item], body=body)
+
+    new_with, alias_name, changed = transform_with_items(w)
+    assert changed
+    r = repr(new_with)
+    assert "caplog" in r
+    assert '"INFO"' in r or "INFO" in r
+
+
+def test_lookahead_rewrites_equality_rhs_getmessage():
+    src = """
+with caplog as log:
+    pass
+assert log.output[0] == 'bad'
+"""
+    mod = cst.parse_module(src)
+    stmts = list(mod.body)
+    # find index of the with
+    idx = 0
+    for i, s in enumerate(stmts):
+        if isinstance(s, cst.With):
+            idx = i
+            break
+    rewrite_following_statements_for_alias(stmts, idx + 1, "log")
+    joined = "\n".join(repr(s) for s in stmts)
+    # RHS equality should be rewritten to caplog.records[0].getMessage() or similar
     assert "caplog" in joined
     assert "getMessage" in joined

--- a/tests/unit/test_assert_transformer_rewrite_helpers.py
+++ b/tests/unit/test_assert_transformer_rewrite_helpers.py
@@ -1,0 +1,79 @@
+import libcst as cst
+
+from splurge_unittest_to_pytest.transformers.assert_transformer import (
+    rewrite_asserts_using_alias_in_with_body,
+    rewrite_following_statements_for_alias,
+)
+
+
+def _parse_stmt(src: str) -> cst.BaseStatement:
+    mod = cst.parse_module(src)
+    # Return first top-level statement
+    return mod.body[0]
+
+
+def test_rewrite_len_in_with_body_subscript_index():
+    src = """
+with caplog as log:
+    assert len(log.output[0]) == 2
+"""
+    with_stmt = _parse_stmt(src)
+    assert isinstance(with_stmt, cst.SimpleStatementLine) or isinstance(with_stmt, cst.With)
+    # If parse gives SimpleStatementLine for 'with' (libcst behavior), reparse as module
+    mod = cst.parse_module(src)
+    w = mod.body[0]
+    assert isinstance(w, cst.With)
+
+    new_with = rewrite_asserts_using_alias_in_with_body(w, "log")
+    # Ensure caplog.records appears in the transformed tree
+    assert "caplog" in repr(new_with)
+    assert "records" in repr(new_with)
+
+
+def test_rewrite_membership_in_with_body_getmessage():
+    src = """
+with caplog as log:
+    assert 'error' in log.output[0]
+"""
+    mod = cst.parse_module(src)
+    w = mod.body[0]
+    new_with = rewrite_asserts_using_alias_in_with_body(w, "log")
+    r = repr(new_with)
+    assert "caplog" in r
+    # membership should include getMessage() call
+    assert "getMessage" in r
+
+
+def test_rewrite_assert_equal_self_inside_with_body():
+    src = """
+with caplog as log:
+    self.assertEqual(len(log.output), 3)
+"""
+    mod = cst.parse_module(src)
+    w = mod.body[0]
+    new_with = rewrite_asserts_using_alias_in_with_body(w, "log")
+    r = repr(new_with)
+    assert "caplog" in r
+
+
+def test_rewrite_following_statements_len_and_membership():
+    src = """
+# preceding block
+with caplog as log:
+    pass
+assert len(log.output) == 1
+assert 'oops' in log.output[0]
+"""
+    mod = cst.parse_module(src)
+    stmts = list(mod.body)
+    # find index of the with
+    idx = 0
+    for i, s in enumerate(stmts):
+        if isinstance(s, cst.With):
+            idx = i
+            break
+    # mutate following statements in place
+    rewrite_following_statements_for_alias(stmts, idx + 1, "log")
+    joined = "\n".join(repr(s) for s in stmts)
+    assert "caplog" in joined
+    assert "getMessage" in joined

--- a/tests/unit/test_assert_transformer_rewrite_single_alias.py
+++ b/tests/unit/test_assert_transformer_rewrite_single_alias.py
@@ -1,0 +1,61 @@
+import libcst as cst
+
+from splurge_unittest_to_pytest.transformers.assert_transformer import (
+    rewrite_single_alias_assert,
+)
+
+
+def _parse_assert(src: str) -> cst.BaseSmallStatement:
+    mod = cst.parse_module(src)
+    # return first statement inside module
+    stmt = mod.body[0]
+    # if it's a SimpleStatementLine with an Assert inside, return that Assert
+    if isinstance(stmt, cst.SimpleStatementLine) and len(stmt.body) == 1 and isinstance(stmt.body[0], cst.Assert):
+        return stmt.body[0]
+    if isinstance(stmt, cst.Assert):
+        return stmt
+    raise RuntimeError("unexpected parse")
+
+
+def test_rewrite_len_subscript():
+    src = "assert len(log.output[0]) == 2"
+    a = _parse_assert(src)
+    new = rewrite_single_alias_assert(a, "log")
+    r = repr(new if new is not None else a)
+    assert "caplog" in r
+    assert "records" in r
+
+
+def test_rewrite_membership_getmessage():
+    src = "assert 'err' in log.output[0]"
+    a = _parse_assert(src)
+    new = rewrite_single_alias_assert(a, "log")
+    r = repr(new if new is not None else a)
+    assert "caplog" in r
+    assert "getMessage" in r
+
+
+def test_rewrite_equality_rhs_getmessage():
+    src = "assert log.output[0] == 'bad'"
+    a = _parse_assert(src)
+    new = rewrite_single_alias_assert(a, "log")
+    r = repr(new if new is not None else a)
+    assert "caplog" in r
+    assert "getMessage" in r
+
+
+def test_rewrite_equality_lhs_records():
+    src = "assert len(log.output) == 3"
+    a = _parse_assert(src)
+    new = rewrite_single_alias_assert(a, "log")
+    r = repr(new if new is not None else a)
+    assert "caplog" in r
+    # for non-subscripted alias.output, expect records used (no getMessage on the whole records)
+    assert "records" in r
+
+
+def test_preserve_no_rewrite():
+    src = "assert 1 == 1"
+    a = _parse_assert(src)
+    new = rewrite_single_alias_assert(a, "log")
+    assert new is None

--- a/tests/unit/test_assert_transformer_rewrite_single_alias_deep_edgecases.py
+++ b/tests/unit/test_assert_transformer_rewrite_single_alias_deep_edgecases.py
@@ -1,0 +1,60 @@
+import libcst as cst
+import pytest
+
+from splurge_unittest_to_pytest.transformers.assert_transformer import (
+    rewrite_single_alias_assert,
+)
+
+
+def _parse_assert(src: str) -> cst.BaseSmallStatement:
+    mod = cst.parse_module(src)
+    stmt = mod.body[0]
+    if isinstance(stmt, cst.SimpleStatementLine) and len(stmt.body) == 1 and isinstance(stmt.body[0], cst.Assert):
+        return stmt.body[0]
+    if isinstance(stmt, cst.Assert):
+        return stmt
+    raise RuntimeError("unexpected parse")
+
+
+def test_deeply_nested_boolean_and_parentheses():
+    src = "assert (('err' in log.output[0]) and ((len(log.output) > 0) or ('x' in log.output[1])))"
+    a = _parse_assert(src)
+    new = rewrite_single_alias_assert(a, "log")
+    r = repr(new if new is not None else a)
+    assert "caplog" in r
+    # ensure at least one getMessage or records access is present
+    assert "getMessage" in r or "records" in r
+
+
+def test_unary_not_parenthesized_comparison():
+    src = "assert not (\n    'err' in log.output[0]\n)"
+    a = _parse_assert(src)
+    new = rewrite_single_alias_assert(a, "log")
+    r = repr(new if new is not None else a)
+    assert "caplog" in r
+
+
+def test_deep_subscript_chain_rewrite_len():
+    src = "assert len(log.output[0][1][2][3]) == 4"
+    a = _parse_assert(src)
+    new = rewrite_single_alias_assert(a, "log")
+    r = repr(new if new is not None else a)
+    assert "caplog" in r
+
+
+def test_unary_not_wrapping_boolean_and_parentheses():
+    # not (( 'err' in log.output[0] ) and ('x' in log.output[1]))
+    src = "assert not (('err' in log.output[0]) and ('x' in log.output[1]))"
+    a = _parse_assert(src)
+    new = rewrite_single_alias_assert(a, "log")
+    r = repr(new if new is not None else a)
+    assert "caplog" in r
+
+
+def test_unary_not_wrapping_boolean_or_no_extra_parens():
+    # not ( 'err' in log.output[0] or 'x' in log.output[1] )
+    src = "assert not ('err' in log.output[0] or 'x' in log.output[1])"
+    a = _parse_assert(src)
+    new = rewrite_single_alias_assert(a, "log")
+    r = repr(new if new is not None else a)
+    assert "caplog" in r

--- a/tests/unit/test_assert_transformer_rewrite_single_alias_edgecases.py
+++ b/tests/unit/test_assert_transformer_rewrite_single_alias_edgecases.py
@@ -1,0 +1,57 @@
+import libcst as cst
+
+from splurge_unittest_to_pytest.transformers.assert_transformer import (
+    rewrite_single_alias_assert,
+)
+
+
+def _parse_assert(src: str) -> cst.BaseSmallStatement:
+    mod = cst.parse_module(src)
+    stmt = mod.body[0]
+    if isinstance(stmt, cst.SimpleStatementLine) and len(stmt.body) == 1 and isinstance(stmt.body[0], cst.Assert):
+        return stmt.body[0]
+    if isinstance(stmt, cst.Assert):
+        return stmt
+    raise RuntimeError("unexpected parse")
+
+
+def test_nested_subscript_and_slice():
+    src = "assert 'x' in log.output[0][1:]"
+    a = _parse_assert(src)
+    new = rewrite_single_alias_assert(a, "log")
+    r = repr(new if new is not None else a)
+    assert "caplog" in r
+    assert "getMessage" in r
+
+
+def test_combined_boolean_and_membership():
+    src = "assert ('err' in log.output[0]) and (len(log.output) > 0)"
+    a = _parse_assert(src)
+    new = rewrite_single_alias_assert(a, "log")
+    # The helper currently rewrites membership and len-sides individually; ensure at least one appearance rewritten
+    r = repr(new if new is not None else a)
+    assert "caplog" in r
+
+
+def test_rhs_equality_with_subscript_on_lhs():
+    src = "assert log.output[1] == other_var"
+    a = _parse_assert(src)
+    new = rewrite_single_alias_assert(a, "log")
+    r = repr(new if new is not None else a)
+    assert "caplog" in r
+    assert "getMessage" in r
+
+
+def test_non_output_attribute_unchanged():
+    src = "assert log.something_else == 'ok'"
+    a = _parse_assert(src)
+    new = rewrite_single_alias_assert(a, "log")
+    assert new is None
+
+
+def test_double_subscript_index():
+    src = "assert len(log.output[0][0]) == 1"
+    a = _parse_assert(src)
+    new = rewrite_single_alias_assert(a, "log")
+    r = repr(new if new is not None else a)
+    assert "caplog" in r

--- a/tests/unit/test_assert_transformer_wrap_and_alias.py
+++ b/tests/unit/test_assert_transformer_wrap_and_alias.py
@@ -2,7 +2,7 @@ import libcst as cst
 
 from splurge_unittest_to_pytest.transformers.assert_transformer import (
     transform_caplog_alias_string_fallback,
-    wrap_assert_logs_in_block,
+    wrap_assert_in_block,
 )
 
 
@@ -22,7 +22,7 @@ def test_fn(self):
     assert isinstance(func, cst.FunctionDef)
     stmts = list(func.body.body)
 
-    out = wrap_assert_logs_in_block(stmts)
+    out = wrap_assert_in_block(stmts)
     # Expect a single With node at start
     assert any(isinstance(s, cst.With) for s in out)
     code = cst.Module(body=out).code

--- a/tests/unit/test_cli_public_api.py
+++ b/tests/unit/test_cli_public_api.py
@@ -13,7 +13,8 @@ def test_create_config_defaults():
     cfg = cli.create_config()
     assert isinstance(cfg, MigrationConfig)
     assert cfg.file_patterns == ["test_*.py"]
-    assert cfg.fixture_scope.value == "function"
+    # fixture_scope is no longer exposed as a CLI option; ensure config created
+    assert hasattr(cfg, "line_length")
 
 
 def test_validate_source_files_with_patterns(tmp_path):

--- a/tests/unit/test_context_public_api.py
+++ b/tests/unit/test_context_public_api.py
@@ -12,7 +12,8 @@ def test_migration_config_roundtrip():
     cfg = MigrationConfig()
     d = cfg.to_dict()
     cfg2 = MigrationConfig.from_dict(d)
-    assert cfg2.fixture_scope == cfg.fixture_scope
+    # fixture_scope removed; ensure roundtrip preserves other keys
+    assert cfg2.line_length == cfg.line_length
 
 
 def test_pipeline_context_create_and_methods(tmp_path):

--- a/tests/unit/test_more_public_apis.py
+++ b/tests/unit/test_more_public_apis.py
@@ -114,9 +114,9 @@ def test_event_timer_publishes(mocker):
 
 
 def test_context_public_api_and_immutability(tmp_path):
-    cfg = create_config(fixture_scope="function", line_length=100)
+    cfg = create_config(line_length=100)
     assert isinstance(cfg, MigrationConfig)
-    assert cfg.fixture_scope == FixtureScope.FUNCTION
+    assert cfg.line_length == 100
 
     src = tmp_path / "x.py"
     src.write_text("print(1)\n")

--- a/tests/unit/test_steps_public_api.py
+++ b/tests/unit/test_steps_public_api.py
@@ -62,7 +62,7 @@ def test_parse_steps_failure_path(tmp_path):
 
 
 def test_format_steps_public_api(tmp_path):
-    config = MigrationConfig(format_code=True, line_length=88)
+    config = MigrationConfig(line_length=88)
     target = tmp_path / "out_format.py"
     context = PipelineContext.create(source_file=__file__, target_file=str(target), config=config)
     code = "import sys\n\n\nprint(1)\n"
@@ -84,7 +84,7 @@ def test_format_steps_warning_on_exception(monkeypatch, tmp_path):
         def _apply_black(self, code, config):
             raise RuntimeError("black failed")
 
-    config = MigrationConfig(format_code=True)
+    config = MigrationConfig()
     target = tmp_path / "out_failfmt.py"
     context = PipelineContext.create(source_file=__file__, target_file=str(target), config=config)
     res = FailingFormat("format", EventBus()).run(context, "print(1)\n")


### PR DESCRIPTION
This pull request focuses on simplifying and modernizing the configuration system for the `splurge_unittest_to_pytest` migration tool, with a particular emphasis on removing legacy and redundant transformation flags from both the CLI and internal configuration. It also adds detailed developer documentation for planned refactoring and rewrite invariants, and makes minor dependency and codebase cleanups.

The most important changes are:

**Configuration and CLI Simplification:**
* Removed legacy transformation flags (`convert_classes_to_functions`, `merge_setup_teardown`, `generate_fixtures`, `fixture_scope`, `format_code`, `optimize_imports`, `add_type_hints`, `parallel_processing`) from the `MigrationConfig` dataclass and CLI surface, ensuring that only essential and currently supported options are exposed and used. Old config files with these keys will be silently accepted but ignored. [[1]](diffhunk://#diff-83828b458dd90b37949feabc8ada16a4f0de9924ad36c7a75046ccc298089781L70-L76) [[2]](diffhunk://#diff-83828b458dd90b37949feabc8ada16a4f0de9924ad36c7a75046ccc298089781L106-L144) [[3]](diffhunk://#diff-83828b458dd90b37949feabc8ada16a4f0de9924ad36c7a75046ccc298089781L313-L314) [[4]](diffhunk://#diff-77e95fd77220415498b082f291b6778b7b280801632e94957e67da661f92b8f3L69-R79) [[5]](diffhunk://#diff-77e95fd77220415498b082f291b6778b7b280801632e94957e67da661f92b8f3L116-R116) [[6]](diffhunk://#diff-77e95fd77220415498b082f291b6778b7b280801632e94957e67da661f92b8f3L237-R235) [[7]](diffhunk://#diff-77e95fd77220415498b082f291b6778b7b280801632e94957e67da661f92b8f3L324-L326) [[8]](diffhunk://#diff-83828b458dd90b37949feabc8ada16a4f0de9924ad36c7a75046ccc298089781L478-R469)
* Updated the YAML config generation and CLI help to omit removed/legacy keys, and clarified which settings are intentionally not exposed.

**Developer Documentation and Refactoring Plans:**
* Added a detailed plan document (`plan-simplification-assert-transformer-2025-09-28.md`) outlining the incremental decomposition of `wrap_assert_in_block` into single-responsibility helpers, with signatures, edge cases, and associated unit/integration test plans.
* Documented invariants and CST parser shapes for safely rewriting assertion expressions referencing log aliases to `caplog` equivalents, providing guidance for future contributors.

**Dependency and Miscellaneous Cleanups:**
* Removed `hypothesis` from the development dependencies in `pyproject.toml`, likely due to it no longer being required for the current test suite.

These changes streamline the tool's configuration, improve maintainability, and provide a clear path for future refactoring and safe code transformations.