### PR TITLE
Fix assert issue

### DIFF
--- a/scripts/debug_transform_steps.py
+++ b/scripts/debug_transform_steps.py
@@ -1,0 +1,37 @@
+import libcst as cst
+from libcst.metadata import MetadataWrapper
+
+from splurge_unittest_to_pytest.transformers.assert_transformer import transform_with_items
+from splurge_unittest_to_pytest.transformers.transformer_helper import ReplacementApplier
+from splurge_unittest_to_pytest.transformers.unittest_transformer import UnittestToPytestCstTransformer
+
+path = "tests/data/given_and_expected/unittest_given_09.txt"
+code = open(path, encoding="utf-8").read()
+module = cst.parse_module(code)
+wrapper = MetadataWrapper(module)
+transf = UnittestToPytestCstTransformer()
+# Run main transformer
+transformed1 = wrapper.visit(transf)
+print("--- after main transformer ---")
+print(transformed1.code)
+# apply replacement registry if any
+if transf.replacement_registry.replacements:
+    applied = MetadataWrapper(transformed1).visit(ReplacementApplier(transf.replacement_registry))
+    print("--- after replacement applier ---")
+    print(applied.code)
+else:
+    applied = transformed1
+    print("--- no replacements recorded ---")
+class RemainingWithRewriter(cst.CSTTransformer):
+    def leave_With(self, original: cst.With, updated: cst.With) -> cst.With:
+        try:
+            new_with, alias, changed = transform_with_items(updated)
+            return new_with
+        except Exception:
+            return updated
+
+
+parsed = cst.parse_module(applied.code)
+final = parsed.visit(RemainingWithRewriter())
+print("--- after RemainingWithRewriter ---")
+print(final.code)

--- a/scripts/inspect_cst_09.py
+++ b/scripts/inspect_cst_09.py
@@ -1,0 +1,26 @@
+import libcst as cst
+
+from splurge_unittest_to_pytest.context import MigrationConfig
+from splurge_unittest_to_pytest.migration_orchestrator import MigrationOrchestrator
+
+orc = MigrationOrchestrator()
+config = MigrationConfig(target_directory=".", backup_originals=False, dry_run=True)
+res = orc.migrate_file("tests/data/given_and_expected/unittest_given_09.txt", config)
+if not res.is_success():
+    print("migration failed", res.error)
+    raise SystemExit(1)
+
+code = res.metadata.get("generated_code")
+print("--- generated code snippet for FileManager.create_file ---")
+mod = cst.parse_module(code)
+for node in mod.body:
+    if isinstance(node, cst.ClassDef) and node.name.value == "FileManager":
+        for stmt in node.body.body:
+            # find create_file
+            if isinstance(stmt, cst.FunctionDef) and stmt.name.value == "create_file":
+                print("Function create_file body statements:")
+                for i, s in enumerate(stmt.body.body):
+                    t = type(s).__name__
+                    print(i, t, "->", getattr(s, "code", lambda: None)() if hasattr(s, "code") else "")
+                raise SystemExit(0)
+print("FileManager.create_file not found")

--- a/scripts/inspect_transform_09.py
+++ b/scripts/inspect_transform_09.py
@@ -1,0 +1,15 @@
+import sys
+
+from splurge_unittest_to_pytest.context import MigrationConfig
+from splurge_unittest_to_pytest.migration_orchestrator import MigrationOrchestrator
+
+p = "tests/data/given_and_expected/unittest_given_09.txt"
+orc = MigrationOrchestrator()
+config = MigrationConfig(target_directory=".", backup_originals=False)
+res = orc.migrate_file(p, config)
+if res.is_success():
+    print(res.data)
+    sys.exit(0)
+else:
+    print("Migration failed:", res.error)
+    sys.exit(2)

--- a/scripts/inspect_transform_09_dry.py
+++ b/scripts/inspect_transform_09_dry.py
@@ -1,0 +1,22 @@
+import sys
+
+from splurge_unittest_to_pytest.context import MigrationConfig
+from splurge_unittest_to_pytest.migration_orchestrator import MigrationOrchestrator
+
+p = "tests/data/given_and_expected/unittest_given_09.txt"
+orc = MigrationOrchestrator()
+config = MigrationConfig(target_directory=".", backup_originals=False, dry_run=True)
+res = orc.migrate_file(p, config)
+if res.is_success():
+    # If dry_run, generated code may be in metadata
+    metadata = getattr(res, "metadata", None) or {}
+    gen = metadata.get("generated_code")
+    if gen:
+        print(gen)
+        sys.exit(0)
+    else:
+        print("No generated_code in metadata; result.data:", res.data)
+        sys.exit(0)
+else:
+    print("Migration failed:", res.error)
+    sys.exit(2)

--- a/scripts/inspect_try_nodes.py
+++ b/scripts/inspect_try_nodes.py
@@ -1,0 +1,24 @@
+import libcst as cst
+
+from splurge_unittest_to_pytest.context import MigrationConfig
+from splurge_unittest_to_pytest.migration_orchestrator import MigrationOrchestrator
+
+orc = MigrationOrchestrator()
+config = MigrationConfig(target_directory=".", backup_originals=False, dry_run=True)
+res = orc.migrate_file("tests/data/given_and_expected/unittest_given_09.txt", config)
+code = res.metadata.get("generated_code")
+mod = cst.parse_module(code)
+for node in mod.body:
+    if isinstance(node, cst.ClassDef) and node.name.value == "FileManager":
+        for func in node.body.body:
+            if isinstance(func, cst.FunctionDef) and func.name.value == "create_file":
+                for stmt in func.body.body:
+                    print("STMT TYPE:", type(stmt).__name__)
+                    print("CODE:\n", stmt.code)
+                    if isinstance(stmt, cst.Try):
+                        print("Try body items:")
+                        for j, inner in enumerate(stmt.body.body):
+                            print("  INNER", j, type(inner).__name__)
+                            print(inner.code)
+                raise SystemExit(0)
+print("Done")

--- a/splurge_unittest_to_pytest/jobs/output_job.py
+++ b/splurge_unittest_to_pytest/jobs/output_job.py
@@ -62,7 +62,12 @@ class OutputJob(Job[str, str]):
 
         # Create backup if requested (skip on dry-run)
         if context.config.backup_originals and not context.config.dry_run:
+            self._logger.info(f"Creating backup for {context.source_file}")
             self._create_backup(context.source_file)
+        else:
+            self._logger.debug(
+                f"Skipping backup: dry_run={context.config.dry_run}, backup={context.config.backup_originals}"
+            )
 
         # Execute the job with the transformed code as input
         result = super().execute(context, initial_input)
@@ -93,5 +98,7 @@ class OutputJob(Job[str, str]):
 
                 shutil.copy2(source_path, backup_path)
                 self._logger.info(f"Created backup: {backup_path}")
+            else:
+                self._logger.info(f"Backup already exists, skipping: {backup_path}")
         except Exception as e:
             self._logger.warning(f"Failed to create backup for {source_file}: {e}")

--- a/tests/data/given_and_expected/unittest_given_01.txt.backup
+++ b/tests/data/given_and_expected/unittest_given_01.txt.backup
@@ -1,25 +1,25 @@
-import pytest
+import unittest
 
 
-class TestBasicMath:
-    @pytest.fixture(autouse=True)
-    def setup_method(self):
+class TestBasicMath(unittest.TestCase):
+    def setUp(self):
         self.calculator = Calculator()
-        yield
+    
+    def tearDown(self):
         self.calculator = None
-
+    
     def test_addition(self):
         result = self.calculator.add(2, 3)
-        assert result == 5
-
+        self.assertEqual(result, 5)
+    
     def test_subtraction(self):
         result = self.calculator.subtract(5, 3)
-        assert result == 2
+        self.assertEqual(result, 2)
 
 
 class Calculator:
     def add(self, a, b):
         return a + b
-
+    
     def subtract(self, a, b):
         return a - b

--- a/unittest_given_09.txt
+++ b/unittest_given_09.txt
@@ -1,0 +1,131 @@
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_module():
+    global temp_dir
+    temp_dir = tempfile.mkdtemp()
+    os.environ["TEST_DATA_DIR"] = temp_dir
+    yield
+    global temp_dir
+    import shutil
+
+    shutil.rmtree(temp_dir)
+    del os.environ["TEST_DATA_DIR"]
+    temp_dir = None
+
+
+class TestFileManager:
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_class(cls):
+        cls.file_manager = FileManager(temp_dir)
+        cls.logger = MagicMock()
+        cls.file_manager.set_logger(cls.logger)
+        yield
+        cls.file_manager = None
+        cls.logger = None
+
+    @pytest.fixture(autouse=True)
+    def setup_method(self):
+        self.test_filename = "test_file.txt"
+        self.test_content = "Test content for file operations"
+        self.test_filepath = os.path.join(temp_dir, self.test_filename)
+        yield
+        if os.path.exists(self.test_filepath):
+            os.remove(self.test_filepath)
+        self.test_filename = None
+        self.test_content = None
+        self.test_filepath = None
+
+    def test_create_file(self):
+        success = self.file_manager.create_file(self.test_filename, self.test_content)
+        assert success
+        assert os.path.exists(self.test_filepath)
+        self.logger.info.assert_called_with(f"File created: {self.test_filename}")
+
+    @patch("builtins.open", side_effect=PermissionError("Access denied"))
+    def test_create_file_permission_error(self, mock_open):
+        success = self.file_manager.create_file(self.test_filename, self.test_content)
+        assert not success
+        self.logger.error.assert_called_with(
+            f"Permission error creating file: {self.test_filename}"
+        )
+
+    def test_read_file_content(self):
+        self.file_manager.create_file(self.test_filename, self.test_content)
+        content = self.file_manager.read_file(self.test_filename)
+        assert content == self.test_content
+
+    def test_file_exists_check(self):
+        assert not self.file_manager.file_exists(self.test_filename)
+        self.file_manager.create_file(self.test_filename, self.test_content)
+        assert self.file_manager.file_exists(self.test_filename)
+
+
+class TestFileProcessor:
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_class(cls):
+        cls.processor = FileProcessor()
+        yield
+        cls.processor = None
+
+    @pytest.fixture(autouse=True)
+    def setup_method(self):
+        self.sample_lines = ["Line 1", "Line 2", "Line 3"]
+        self.sample_text = "\n".join(self.sample_lines)
+        yield
+        self.sample_lines = None
+        self.sample_text = None
+
+    def test_count_lines(self):
+        count = self.processor.count_lines(self.sample_text)
+        assert count == 3
+
+    def test_count_words(self):
+        count = self.processor.count_words(self.sample_text)
+        assert count == 6
+
+
+class FileManager:
+    def __init__(self, base_dir):
+        self.base_dir = base_dir
+        self.logger = None
+
+    def set_logger(self, logger):
+        self.logger = logger
+
+    def create_file(self, filename, content):
+        filepath = os.path.join(self.base_dir, filename)
+        try:
+            with open(filepath, "w") as f:
+                f.write(content)
+            with open(filepath, "w") as f:
+                f.write(content)
+            return True
+        except PermissionError:
+            if self.logger:
+                self.logger.error(f"Permission error creating file: {filename}")
+            return False
+
+    def read_file(self, filename):
+        filepath = os.path.join(self.base_dir, filename)
+        with open(filepath, "r") as f:
+            return f.read()
+        with open(filepath, "r") as f:
+            return f.read()
+
+    def file_exists(self, filename):
+        filepath = os.path.join(self.base_dir, filename)
+        return os.path.exists(filepath)
+
+
+class FileProcessor:
+    def count_lines(self, text):
+        return len(text.split("\n"))
+
+    def count_words(self, text):
+        return len(text.split())


### PR DESCRIPTION
This pull request introduces several new debugging and inspection scripts to assist with the migration and transformation of test files, and makes a series of improvements to logging, file validation, and backup handling in the main CLI and output job logic. Additionally, minor debug and comment additions are made in the assertion transformer for clarity during transformation development.

**Key changes:**

### New debugging and inspection scripts

* Added multiple scripts under `scripts/` for debugging and inspecting the migration and transformation process, including `debug_transform_steps.py`, `inspect_cst_09.py`, `inspect_transform_09.py`, `inspect_transform_09_dry.py`, and `inspect_try_nodes.py`. These scripts help developers step through transformation logic, inspect CST nodes, and verify migration outputs on sample files. [[1]](diffhunk://#diff-899a6ad60e40cad35046a6411cbc1ab429651200d14746fb71809eed87ed3657R1-R37) [[2]](diffhunk://#diff-89407e7d03ab8983dfed5e27f6dc04e10ac581e9f3dcee45b2e0b3f8a1aa13dbR1-R26) [[3]](diffhunk://#diff-43971e2562a75057d96c2885d961c056159611a594dad09b663e954474637eb0R1-R15) [[4]](diffhunk://#diff-a47864be6fc86d279b3175cbd3e7c1471ae078b6ec42807b88402370efe184d7R1-R22) [[5]](diffhunk://#diff-25269f5b47472529c6230f713110245b16080f9150de238098a2c3bfe609f669R1-R24)

### Logging and CLI improvements

* Improved logging configuration in `setup_logging` to set the root logger to INFO by default and enable DEBUG logging only for the project package when verbose mode is enabled, reducing noise from third-party libraries.
* Changed the default for the `--quiet` CLI flag to `True`, so informational logging is suppressed unless explicitly disabled.

### File validation and backup handling

* Updated file validation logic to accept any file type (not just `.py`) when explicit files are provided, enabling use of test fixtures with other extensions in dry-run or test scenarios. Directory inputs still recursively find Python files by default. [[1]](diffhunk://#diff-83828b458dd90b37949feabc8ada16a4f0de9924ad36c7a75046ccc298089781L189-R219) [[2]](diffhunk://#diff-83828b458dd90b37949feabc8ada16a4f0de9924ad36c7a75046ccc298089781L249-R276)
* Enhanced backup logic in the output job to log when backups are created or skipped (e.g., in dry-run mode or if a backup already exists), improving visibility into backup behavior. [[1]](diffhunk://#diff-e35e5725f466ace22a23ef42eb9144f37a658b658eac16fcbf2b13cf9783a675R65-R70) [[2]](diffhunk://#diff-e35e5725f466ace22a23ef42eb9144f37a658b658eac16fcbf2b13cf9783a675R101-R102)

### Assertion transformer debug and clarity improvements

* Added debug print statements and clarifying comments in the assertion transformer to assist with development and troubleshooting of transformation logic, particularly for context manager and assertion rewrites. [[1]](diffhunk://#diff-9a93efbea644c1485fa4293e01f23eac7413fcb185fb0e7f2349a5615ed80c0eR27-R28) [[2]](diffhunk://#diff-9a93efbea644c1485fa4293e01f23eac7413fcb185fb0e7f2349a5615ed80c0eR589-R593) [[3]](diffhunk://#diff-9a93efbea644c1485fa4293e01f23eac7413fcb185fb0e7f2349a5615ed80c0eR626) [[4]](diffhunk://#diff-9a93efbea644c1485fa4293e01f23eac7413fcb185fb0e7f2349a5615ed80c0eR647) [[5]](diffhunk://#diff-9a93efbea644c1485fa4293e01f23eac7413fcb185fb0e7f2349a5615ed80c0eR659) [[6]](diffhunk://#diff-9a93efbea644c1485fa4293e01f23eac7413fcb185fb0e7f2349a5615ed80c0eR674)