### PR TITLE
Enhance documentation and logging; refactor CLI options and transformers; add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ an alternate location.
   ``unittest.TestCase`` are preserved to maintain class-scoped fixtures and
   organization unless a conversion is explicitly desired.
 - Backups of originals are available via ``--backup``.
+ - Backups of originals are available via ``--backup`` (off by default; pass ``--backup`` to enable).
 - Configurable discovery patterns, test method prefixes, and other options
   via the CLI or a programmatic ``MigrationConfig``.
 
@@ -50,16 +51,15 @@ See `docs/README-DETAILS.md` for a comprehensive feature and CLI reference.
 
 - ``-d, --dir DIR``: Root directory for discovery
 - ``-f, --file PATTERN``: Glob pattern(s) to select files (repeatable)
-- ``-r, --recurse/--no-recurse``: Recurse directories (default: recurse)
-- ``-t, --target-dir DIR``: Directory to write converted files
-- ``--dry-run``: Preview generated output without writing files
-- ``--diff``: When used with ``--dry-run``, show unified diffs
-- ``--list``: When used with ``--dry-run``, list files only
-- ``--posix``: Force POSIX-style path output in dry-run mode
-- ``--quiet``: Suppress extras in dry-run output
-- ``--ext EXT``: Override the target file extension
-- ``--suffix SUFFIX``: Append a suffix to converted filenames
-- ``--backup/--no-backup``: Create backup copies of originals
+ - ``--dry-run``: Preview generated output without writing files (presence-only flag)
+ - ``--diff``: When used with ``--dry-run``, show unified diffs (presence-only flag)
+ - ``--list``: When used with ``--dry-run``, list files only (presence-only flag)
+ - ``--posix``: Force POSIX-style path output in dry-run mode (presence-only flag)
+ - ``--quiet``: Suppress extras in dry-run output (presence-only flag)
+ - ``--suffix SUFFIX``: Append a suffix to converted filenames
+ - ``--backup``: Create backup copies of originals when writing (presence-only flag; default: off)
+ - ``--suffix SUFFIX``: Append a suffix to converted filenames
+ - ``--backup``: Create backup copies of originals when writing (presence-only flag; default: off)
 - ``--prefix PREFIX``: Allowed test method prefixes (repeatable; default: ``test``)
 
 For the full set of flags and detailed help, run:

--- a/docs/README-DETAILS.md
+++ b/docs/README-DETAILS.md
@@ -133,7 +133,7 @@ All flags are available on the ``migrate`` command. Summary below; use
 - ``-r, --recurse / --no-recurse``: Recurse directories (default: recurse).
 - ``-t, --target-dir DIR``: Directory to write outputs.
 - ``--preserve-structure / --no-preserve-structure``: Preserve original directory layout (default: preserve).
-- ``--backup / --no-backup``: Create a ``.backup`` copy of originals when writing (default: backup).
+ - ``--backup``: Create a ``.backup`` copy of originals when writing (presence-only flag; default: off).
 - ``--line-length N``: Max line length used by formatters (default: 120).
 - ``--dry-run``: Do not write files; return or display generated output.
 	- With ``--dry-run --diff``: show unified diffs.
@@ -141,7 +141,15 @@ All flags are available on the ``migrate`` command. Summary below; use
 - ``--ext EXT``: Override the target file extension.
 - ``--suffix SUFFIX``: Append suffix to target filename stem when writing.
 - ``--fail-fast``: Stop on first error (default: off).
-- ``-v, --verbose``: Verbose logging.
+ - ``-v, --verbose``: Verbose logging (presence-only flag). Note: ``--verbose`` and ``--quiet`` are mutually exclusive; do not pass both.
+ - ``--dry-run``: Do not write files; return or display generated output (presence-only flag).
+	 - With ``--dry-run --diff``: show unified diffs (``--diff`` is presence-only).
+	 - With ``--dry-run --list``: list files only (``--list`` is presence-only).
+ - ``--diff``: Show unified diffs in dry-run mode (presence-only flag).
+ - ``--list``: List files only in dry-run mode (presence-only flag).
+ - ``--posix``: Format displayed file paths using POSIX separators when True (presence-only flag).
+ - ``--fail-fast``: Stop on first error (presence-only flag).
+ - ``--parametrize``: Attempt conservative subTest -> parametrize conversions (presence-only flag).
 - ``--report / --no-report``: Generate a migration report (default: on).
 - ``--report-format [json|html|markdown]``: Report format (default: json).
 - ``--config FILE``: Load configuration from YAML file.
@@ -206,6 +214,17 @@ Safety and limitations
 	project tests after migration. The tool aims to be conservative and
 	preserve behavior, but automated transformations require manual
 	verification in complex cases.
+
+Note on top-level __main__ guards and runtime test invocations
+------------------------------------------------------------
+
+- The transformer removes top-level ``if __name__ == "__main__":`` guard
+	blocks and any top-level calls to ``unittest.main()`` or ``pytest.main()``.
+	This avoids emitting runtime test-invocation code in transformed files.
+	The expectation is that tests are executed via the command line or a
+	test runner (for example, ``pytest``). If you need to preserve these
+	guards for runnable transformed files, please open an issue or feature
+	request — there is no preservation option in the current release.
 
 Developer notes
 ---------------

--- a/scripts/debug_transform_steps.py
+++ b/scripts/debug_transform_steps.py
@@ -22,6 +22,8 @@ if transf.replacement_registry.replacements:
 else:
     applied = transformed1
     print("--- no replacements recorded ---")
+
+
 class RemainingWithRewriter(cst.CSTTransformer):
     def leave_With(self, original: cst.With, updated: cst.With) -> cst.With:
         try:

--- a/tests/data/given_and_expected/pytest_expected_21.txt
+++ b/tests/data/given_and_expected/pytest_expected_21.txt
@@ -152,4 +152,4 @@ class TestCalculatorComplete:
 
         assert content == b"test content"
 
-pytest.main()
+

--- a/tests/data/given_and_expected/pytest_expected_31.txt
+++ b/tests/data/given_and_expected/pytest_expected_31.txt
@@ -30,4 +30,4 @@ def test_standalone_pytest():
     assert True
 
 
-pytest.main()
+ 

--- a/tests/data/given_and_expected/pytest_expected_32.txt
+++ b/tests/data/given_and_expected/pytest_expected_32.txt
@@ -25,4 +25,3 @@ def test_already_pytest_style():
     assert 1 + 1 == 2
 
 
-pytest.main()

--- a/tests/integration/test_assertion_transformation.py
+++ b/tests/integration/test_assertion_transformation.py
@@ -266,7 +266,10 @@ if __name__ == "__main__":
 
         # Verify unittest references are transformed
         assert "unittest.TestCase" not in transformed
-        assert "pytest.main()" in transformed  # unittest.main() should be transformed to pytest.main()
+        # When the original file only had a bare unittest.main() guarded by
+        # `if __name__ == "__main__":` we intentionally do not append a
+        # top-level pytest.main() in the transformed output.
+        assert "pytest.main()" not in transformed
 
         # Verify original assertions are gone
         assert "self.assertEqual" not in transformed

--- a/tests/unit/test_assert_transformer_focused.py
+++ b/tests/unit/test_assert_transformer_focused.py
@@ -1,0 +1,32 @@
+import libcst as cst
+
+from splurge_unittest_to_pytest.transformers import assert_transformer as at
+
+
+def test_assert_transformer_eq_and_unary_rewrites():
+    # Build a Comparison node representing: not ('err' in log.output[0])
+    alias = "log"
+    # Create AST for: assert not ('err' in log.output[0])
+    left = cst.SimpleString(value="'err'")
+    sub = cst.Subscript(
+        value=cst.Attribute(value=cst.Name(value=alias), attr=cst.Name(value="output")),
+        slice=[cst.SubscriptElement(slice=cst.Index(value=cst.Integer(value="0")))],
+    )
+    comp = cst.Comparison(left=left, comparisons=[cst.ComparisonTarget(operator=cst.In(), comparator=sub)])
+    unary = cst.UnaryOperation(operator=cst.Not(), expression=comp)
+
+    # wrap as an Assert to pass to helpers
+    # Try calling the internal helper if present; otherwise ensure no exception
+    rewritten = None
+    if hasattr(at, "_try_unary_comparison_rewrite"):
+        rewritten = at._try_unary_comparison_rewrite(unary)
+    assert rewritten is None or isinstance(rewritten, cst.Assert)
+
+
+def test_rewrite_asserts_using_alias_in_with_body_no_crash():
+    with_node = cst.parse_statement("""
+with something as log:
+    assert 'x' in log.output[0]
+""")
+    out = at.rewrite_asserts_using_alias_in_with_body(with_node, "log")
+    assert isinstance(out, cst.With)

--- a/tests/unit/test_events_focused.py
+++ b/tests/unit/test_events_focused.py
@@ -1,0 +1,68 @@
+import time
+
+from splurge_unittest_to_pytest.events import EventBus, EventTimer, StepCompletedEvent
+
+
+def test_eventbus_subscribe_publish_and_timer_publish():
+    bus = EventBus()
+    received = []
+
+    def handler(evt):
+        received.append(type(evt))
+
+    bus.subscribe(StepCompletedEvent, handler)
+    # publish a StepCompletedEvent
+    evt = StepCompletedEvent(
+        timestamp=time.time(),
+        run_id="r",
+        context=type("C", (), {"source_file": "s", "target_file": "t", "run_id": "r"})(),
+        step_name="s",
+        step_type="st",
+        result=type("R", (), {"status": type("S", (), {"value": "ok"})()})(),
+        duration_ms=1.0,
+    )
+    bus.publish(evt)
+    assert StepCompletedEvent in received
+
+    # Test EventTimer start/end flow publishes events
+    ctx = type("Ctx", (), {"source_file": "s", "target_file": "t", "run_id": "rid"})()
+    timer = EventTimer(bus, run_id="rid")
+    timer.start_operation("step_write", ctx)
+    res = type("R2", (), {"status": type("S2", (), {"value": "ok"})()})()
+    dur = timer.end_operation("step_write", res)
+    assert isinstance(dur, float)
+
+
+def test_eventbus_publish_handler_raises_but_others_receive():
+    bus = EventBus()
+    calls = []
+
+    def a(evt):
+        calls.append("a")
+
+    def b(evt):
+        calls.append("b")
+        raise RuntimeError("boom")
+
+    def c(evt):
+        calls.append("c")
+
+    bus.subscribe(StepCompletedEvent, a)
+    bus.subscribe(StepCompletedEvent, b)
+    bus.subscribe(StepCompletedEvent, c)
+
+    evt = StepCompletedEvent(
+        timestamp=time.time(),
+        run_id="r",
+        context=type("C", (), {})(),
+        step_name="s",
+        step_type="t",
+        result=type("R", (), {"status": type("S", (), {"value": "ok"})()})(),
+        duration_ms=0.1,
+    )
+    # Should not raise despite b raising
+    bus.publish(evt)
+    assert calls[0] == "a"
+    # b should have been called and appended before raising
+    assert "b" in calls
+    assert "c" in calls

--- a/tests/unit/test_focused_coverage.py
+++ b/tests/unit/test_focused_coverage.py
@@ -1,0 +1,155 @@
+import time
+from pathlib import Path
+
+import libcst as cst
+
+from splurge_unittest_to_pytest.events import EventBus, EventTimer, PipelineStartedEvent, StepCompletedEvent
+from splurge_unittest_to_pytest.migration_orchestrator import MigrationOrchestrator
+from splurge_unittest_to_pytest.transformers import assert_transformer as at
+from splurge_unittest_to_pytest.transformers import import_transformer as it
+
+
+def test_add_pytest_imports_inserts_pytest_and_re_alias():
+    src = """import os
+from something import x
+"""
+
+    class Dummy:
+        needs_re_import = True
+        re_alias = "re2"
+
+    out = it.add_pytest_imports(src, transformer=Dummy())
+    assert "import pytest" in out
+    assert "import re as re2" in out or "import re2" in out
+
+
+def test_remove_unittest_imports_if_unused_removes():
+    src = """import unittest
+def f():
+    return 1
+"""
+    out = it.remove_unittest_imports_if_unused(src)
+    assert "import unittest" not in out
+
+
+def test_assert_transformer_eq_and_unary_rewrites():
+    # Build a Comparison node representing: not ('err' in log.output[0])
+    alias = "log"
+    # Create AST for: assert not ('err' in log.output[0])
+    left = cst.SimpleString(value="'err'")
+    sub = cst.Subscript(
+        value=cst.Attribute(value=cst.Name(value=alias), attr=cst.Name(value="output")),
+        slice=[cst.SubscriptElement(slice=cst.Index(value=cst.Integer(value="0")))],
+    )
+    comp = cst.Comparison(left=left, comparisons=[cst.ComparisonTarget(operator=cst.In(), comparator=sub)])
+    unary = cst.UnaryOperation(operator=cst.Not(), expression=comp)
+
+    # wrap as an Assert to pass to helpers
+    rewritten = at._try_unary_comparison_rewrite(unary) if hasattr(at, "_try_unary_comparison_rewrite") else None
+    # The helper may return None or an Assert; ensure it doesn't raise and handles the shape
+    assert rewritten is None or isinstance(rewritten, cst.Assert)
+
+
+def test_rewrite_asserts_using_alias_in_with_body_no_crash():
+    # Construct a With by parsing source; this ensures a valid libcst With node
+    with_node = cst.parse_statement("""
+with something as log:
+    assert 'x' in log.output[0]
+""")
+    out = at.rewrite_asserts_using_alias_in_with_body(with_node, "log")
+    assert isinstance(out, cst.With)
+
+
+def test_eventbus_subscribe_publish_and_timer_publish():
+    bus = EventBus()
+    received = []
+
+    def handler(evt):
+        received.append(type(evt))
+
+    bus.subscribe(StepCompletedEvent, handler)
+    # publish a StepCompletedEvent
+    evt = StepCompletedEvent(
+        timestamp=time.time(),
+        run_id="r",
+        context=type("C", (), {"source_file": "s", "target_file": "t", "run_id": "r"})(),
+        step_name="s",
+        step_type="st",
+        result=type("R", (), {"status": type("S", (), {"value": "ok"})()})(),
+        duration_ms=1.0,
+    )
+    bus.publish(evt)
+    assert StepCompletedEvent in received
+
+    # Test EventTimer start/end flow publishes events
+    ctx = type("Ctx", (), {"source_file": "s", "target_file": "t", "run_id": "rid"})()
+    timer = EventTimer(bus, run_id="rid")
+    timer.start_operation("step_write", ctx)
+    res = type("R2", (), {"status": type("S2", (), {"value": "ok"})()})()
+    dur = timer.end_operation("step_write", res)
+    assert isinstance(dur, float)
+
+
+def test_migration_orchestrator_migrate_directory_no_files(tmp_path):
+    orch = MigrationOrchestrator()
+    # Create an empty directory
+    d = tmp_path / "empty"
+    d.mkdir()
+    res = orch.migrate_directory(str(d))
+    assert res.is_success()
+    assert res.data == []
+
+
+def test_add_pytest_imports_detects_dynamic_import():
+    src = """# dynamic import
+__import__('pytest')
+"""
+    out = it.add_pytest_imports(src, transformer=None)
+    # dynamic import should be treated as evidence; function should not inject an explicit top-level import
+    assert "__import__('pytest')" in out
+    assert "import pytest" not in out
+
+
+def test_eventbus_publish_handler_raises_but_others_receive():
+    bus = EventBus()
+    calls = []
+
+    def a(evt):
+        calls.append("a")
+
+    def b(evt):
+        calls.append("b")
+        raise RuntimeError("boom")
+
+    def c(evt):
+        calls.append("c")
+
+    bus.subscribe(StepCompletedEvent, a)
+    bus.subscribe(StepCompletedEvent, b)
+    bus.subscribe(StepCompletedEvent, c)
+
+    evt = StepCompletedEvent(
+        timestamp=time.time(),
+        run_id="r",
+        context=type("C", (), {})(),
+        step_name="s",
+        step_type="t",
+        result=type("R", (), {"status": type("S", (), {"value": "ok"})()})(),
+        duration_ms=0.1,
+    )
+    # Should not raise despite b raising
+    bus.publish(evt)
+    assert calls[0] == "a"
+    # b should have been called and appended before raising
+    assert "b" in calls
+    assert "c" in calls
+
+
+def test_migrate_file_missing_source_returns_failure():
+    orch = MigrationOrchestrator()
+    # PipelineContext.create validates the source and raises ValueError for missing file
+    try:
+        orch.migrate_file("this_file_does_not_exist_12345.py")
+        raise AssertionError("Expected migrate_file to raise ValueError for missing source")
+    except ValueError as e:
+        assert "Source file does not exist" in str(e)

--- a/tests/unit/test_import_transformer_focused.py
+++ b/tests/unit/test_import_transformer_focused.py
@@ -1,0 +1,36 @@
+import libcst as cst
+
+from splurge_unittest_to_pytest.transformers import import_transformer as it
+
+
+def test_add_pytest_imports_inserts_pytest_and_re_alias():
+    src = """import os
+from something import x
+"""
+
+    class Dummy:
+        needs_re_import = True
+        re_alias = "re2"
+
+    out = it.add_pytest_imports(src, transformer=Dummy())
+    assert "import pytest" in out
+    assert "import re as re2" in out or "import re2" in out
+
+
+def test_add_pytest_imports_detects_dynamic_import():
+    src = """# dynamic import
+__import__('pytest')
+"""
+    out = it.add_pytest_imports(src, transformer=None)
+    # dynamic import should be treated as evidence; function should not inject an explicit top-level import
+    assert "__import__('pytest')" in out
+    assert "import pytest" not in out
+
+
+def test_remove_unittest_imports_if_unused_removes():
+    src = """import unittest
+def f():
+    return 1
+"""
+    out = it.remove_unittest_imports_if_unused(src)
+    assert "import unittest" not in out

--- a/tests/unit/test_migration_orchestrator_focused.py
+++ b/tests/unit/test_migration_orchestrator_focused.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from splurge_unittest_to_pytest.migration_orchestrator import MigrationOrchestrator
+
+
+def test_migration_orchestrator_migrate_directory_no_files(tmp_path):
+    orch = MigrationOrchestrator()
+    # Create an empty directory
+    d = tmp_path / "empty"
+    d.mkdir()
+    res = orch.migrate_directory(str(d))
+    assert res.is_success()
+    assert res.data == []
+
+
+def test_migrate_file_missing_source_raises_validation():
+    orch = MigrationOrchestrator()
+    try:
+        orch.migrate_file("this_file_does_not_exist_12345.py")
+        raise AssertionError("Expected migrate_file to raise ValueError for missing source")
+    except ValueError as e:
+        assert "Source file does not exist" in str(e)


### PR DESCRIPTION
This pull request makes several improvements to the CLI, documentation, and transformation logic for the unittest-to-pytest migration tool. The main focus is on clarifying and standardizing CLI flags (especially presence-only flags), updating documentation to match, and changing the transformer to never emit top-level test-invocation code (like `pytest.main()`) in converted files. This results in more predictable, cleaner outputs and a clearer user experience.

**CLI and Documentation Improvements:**

* Standardized CLI flags to be presence-only (e.g., `--backup`, `--dry-run`, `--diff`, `--list`, `--posix`, `--quiet`, `--verbose`, `--debug`, `--fail-fast`, `--parametrize`), updated defaults (e.g., `--backup` now defaults to off), and improved mutual exclusivity between `--verbose` and `--debug` (`splurge_unittest_to_pytest/cli.py`, `README.md`, `docs/README-DETAILS.md`). [[1]](diffhunk://#diff-83828b458dd90b37949feabc8ada16a4f0de9924ad36c7a75046ccc298089781L319-R350) [[2]](diffhunk://#diff-83828b458dd90b37949feabc8ada16a4f0de9924ad36c7a75046ccc298089781L367-R402) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L53-R62) [[4]](diffhunk://#diff-eaaece26412e44100bfab3b49fb7df146af125ec89ffc8e46fd66a90182e6860L136-R152)
* Updated documentation to clarify the behavior of presence-only flags, their defaults, and added detailed explanations for each CLI option (`README.md`, `docs/README-DETAILS.md`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R44) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L53-R62) [[3]](diffhunk://#diff-eaaece26412e44100bfab3b49fb7df146af125ec89ffc8e46fd66a90182e6860L136-R152)
* Added a new documentation section explaining that top-level `if __name__ == "__main__"` guards and runtime test invocations are removed by default, with no preservation option in the current release (`docs/README-DETAILS.md`).

**Transformation Logic Changes:**

* Changed the transformer to always remove top-level `if __name__ == "__main__"` guards and any direct calls to `unittest.main()` or `pytest.main()`. No top-level `pytest.main()` is emitted in converted files, resulting in cleaner outputs and more predictable test execution (`splurge_unittest_to_pytest/transformers/unittest_transformer.py`). [[1]](diffhunk://#diff-a406477bda662099fbd58f79d3a01ea6101cb8ccf36950460f79313620ce646cL253-R257) [[2]](diffhunk://#diff-a406477bda662099fbd58f79d3a01ea6101cb8ccf36950460f79313620ce646cR278-R316) [[3]](diffhunk://#diff-a406477bda662099fbd58f79d3a01ea6101cb8ccf36950460f79313620ce646cL447-R439)

**Test and Example Updates:**

* Updated test expectations and example outputs to reflect that `pytest.main()` is no longer added to transformed files (`tests/data/given_and_expected/pytest_expected_21.txt`, `tests/data/given_and_expected/pytest_expected_31.txt`, `tests/data/given_and_expected/pytest_expected_32.txt`, `tests/integration/test_assertion_transformation.py`). [[1]](diffhunk://#diff-027361218ea45b2007cc680a39aa08773ea26671fc6157177a723b78699be1edL155-R155) [[2]](diffhunk://#diff-0cf5455ba8708b5b643ebff0b844fa554e2457c0d108b2f81ee4298a846ef267L33-R33) [[3]](diffhunk://#diff-5acdf3e767c6711d60d0768072f5330f67efbb01b74d964d8e90b14c7db1f0cbL28) [[4]](diffhunk://#diff-d38f20236247c1e5e39180279347c35ac5dc55920160e4bc78219aadd10c2a93L269-R272)

**Minor Refactoring:**

* Improved logging setup and parameter naming for clarity, and made debug/verbose logging mutually exclusive (`splurge_unittest_to_pytest/cli.py`). [[1]](diffhunk://#diff-83828b458dd90b37949feabc8ada16a4f0de9924ad36c7a75046ccc298089781L30-R43) [[2]](diffhunk://#diff-83828b458dd90b37949feabc8ada16a4f0de9924ad36c7a75046ccc298089781L56-R56)
* Minor whitespace and code cleanup (`scripts/debug_transform_steps.py`).

These changes together make the CLI more user-friendly, ensure documentation matches actual behavior, and produce more consistent and idiomatic pytest outputs.