### PR TITLE
feat: enable parametrization by default and streamline subTest handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Updated `UnittestToPytestCstTransformer.visit_FunctionDef` to populate `FixtureCollectionState` containers directly.
 - Ensured module/class fixture helpers use the shared state container while preserving legacy attribute accessors.
+- Defaulted migration configuration and CST transformer to enable conservative subTest → `pytest.mark.parametrize` conversions; use `--subtest` or `--no-parametrize` to opt out.
+- Removed the internal `subtest` configuration flag in favor of a single boolean `parametrize` option while keeping the CLI `--subtest` switch for compatibility.
 
 ### Testing
 - `pytest tests/unit/test_unittest_transformer_structure.py`
+- `pytest tests/unit/test_subtest_parametrize_flag.py tests/unit/test_subtest_parametrize_expanded.py`
 
 ## [2025.0.0] - 2024-09-27
 

--- a/splurge_unittest_to_pytest/context.py
+++ b/splurge_unittest_to_pytest/context.py
@@ -96,13 +96,9 @@ class MigrationConfig:
     fail_fast: bool = False
     # parallel_processing removed; library no longer exposes parallelism flag
     # Optional transforms
-    parametrize: bool = False
+    parametrize: bool = True
     parametrize_ids: bool = True
     parametrize_type_hints: bool = True
-    # New option: explicit subtest behavior. When True preserve
-    # unittest.subTest semantics (use pytest-subtests). When False (default)
-    # prefer parametrize behavior.
-    subtest: bool = False
 
     # Reporting settings
     verbose: bool = False
@@ -400,18 +396,6 @@ class ContextManager:
 
         if config.report_format not in ["json", "html", "markdown"]:
             issues.append("report_format must be one of: json, html, markdown")
-
-        # Validate mutually exclusive flags: `parametrize` and `subtest` should
-        # not both be enabled. Historically both flags existed during a
-        # transitional period; require callers to pick one behavior to avoid
-        # ambiguous transformation semantics.
-        if getattr(config, "parametrize", False) and getattr(config, "subtest", False):
-            # This is a hard failure because the pipeline cannot deterministically
-            # decide which transformation strategy to apply when both are set.
-            return Result.failure(
-                ValueError("Configuration invalid: 'parametrize' and 'subtest' are mutually exclusive"),
-                {"parametrize": config.parametrize, "subtest": config.subtest},
-            )
 
         if issues:
             return Result.warning(config, [f"Configuration issues: {', '.join(issues)}"])

--- a/splurge_unittest_to_pytest/steps/parse_steps.py
+++ b/splurge_unittest_to_pytest/steps/parse_steps.py
@@ -63,16 +63,11 @@ class TransformUnittestStep(Step[cst.Module, cst.Module]):
             ``libcst.Module`` or a failure result with the exception.
         """
         try:
-            # Determine effective parametrize behavior. We introduce a
-            # tri-state `subtest` config: when `subtest` is None we fall back
-            # to `parametrize` for backward compatibility. When `subtest` is
-            # True we preserve unittest.subTest semantics (no parametrize),
-            # otherwise parametrize is used.
+            # Determine effective parametrize behavior directly from the
+            # configuration flag. When disabled we skip parametrize-specific
+            # rewrites and retain subTest semantics.
             cfg = context.config
-            # If the user explicitly requested subtest-preserving mode (cfg.subtest
-            # is True) do not parametrize. Otherwise fall back to the legacy
-            # `parametrize` config value (keeps previous conservative default).
-            effective_parametrize = False if bool(cfg.subtest) else bool(cfg.parametrize)
+            effective_parametrize = bool(cfg.parametrize)
 
             # Use full transform_code to include assertion replacements and imports
             transformer = UnittestToPytestCstTransformer(

--- a/splurge_unittest_to_pytest/transformers/subtest_transformer.py
+++ b/splurge_unittest_to_pytest/transformers/subtest_transformer.py
@@ -51,7 +51,20 @@ def convert_simple_subtests_to_parametrize(
 ) -> cst.FunctionDef | None:
     """Delegate to the parametrization helper module."""
 
-    return convert_subtest_loop_to_parametrize(original_func, updated_func, transformer)
+    current = updated_func
+    changed = False
+
+    while True:
+        converted = convert_subtest_loop_to_parametrize(current, current, transformer)
+        if converted is None:
+            break
+        changed = True
+        current = converted
+
+    if not changed:
+        return None
+
+    return current
 
 
 def convert_subtests_in_body(statements: Sequence[cst.CSTNode]) -> list[cst.BaseStatement]:

--- a/splurge_unittest_to_pytest/transformers/unittest_transformer.py
+++ b/splurge_unittest_to_pytest/transformers/unittest_transformer.py
@@ -256,7 +256,7 @@ class UnittestToPytestCstTransformer(cst.CSTTransformer):
     def __init__(
         self,
         test_prefixes: list[str] | None = None,
-        parametrize: bool = False,
+        parametrize: bool = True,
         parametrize_include_ids: bool | None = None,
         parametrize_add_annotations: bool | None = None,
     ) -> None:

--- a/tests/data/given_and_expected/pytest_expected_32.txt
+++ b/tests/data/given_and_expected/pytest_expected_32.txt
@@ -15,10 +15,9 @@ class TestMultiInherit(BaseTest):
         m.method.return_value = 42
         assert m.method() == 42
 
-    def test_with_subtests(self):
-        for i in range(3):
-            with subtests.test(i=i):
-                assert i < 5
+    @pytest.mark.parametrize("i", [0, 1, 2], ids=["row_0", "row_1", "row_2"])
+    def test_with_subtests(self, i: int):
+        assert i < 5
 
 
 def test_already_pytest_style():

--- a/tests/data/given_and_expected/pytest_expected_40.txt
+++ b/tests/data/given_and_expected/pytest_expected_40.txt
@@ -2,7 +2,6 @@ import pytest
 
 
 class T:
-    def test_nested(self, subtests):
-        for i in [1, 2]:
-            with subtests.test(i=i):
-                assert str(i) == str(i)
+    @pytest.mark.parametrize("i", [1, 2], ids=["row_0", "row_1"])
+    def test_nested(self, i: int):
+        assert str(i) == str(i)

--- a/tests/data/given_and_expected/pytest_expected_42.txt
+++ b/tests/data/given_and_expected/pytest_expected_42.txt
@@ -4,7 +4,6 @@ import pytest
 
 
 class T:
-    def test_regex(self, subtests):
-        for a, b in [("a1", "a"), ("b2", "b")]:
-            with subtests.test(a=a, b=b):
-                assert re.search(r"[a-z]\d", a)
+    @pytest.mark.parametrize("a,b", [("a1", "a"), ("b2", "b")], ids=["row_0", "row_1"])
+    def test_regex(self, a: str, b: str):
+        assert re.search(r"[a-z]\d", a)

--- a/tests/integration/test_complex_subtest_cases.py
+++ b/tests/integration/test_complex_subtest_cases.py
@@ -22,10 +22,9 @@ def _read(path: pathlib.Path) -> str:
 def _run_conversion_and_get_outputs(given: pathlib.Path) -> str:
     # Use the public migrate API to convert a file path with dry_run so we
     # can capture the generated code from the returned Result metadata.
-    # Request a dry-run and explicitly set subtest=False so the pipeline
-    # will prefer parametrize-style pytest output. Do not pass `parametrize`
-    # here; the pipeline computes parametrize based on the subtest flag.
-    cfg = MigrationConfig().with_override(dry_run=True, subtest=False, parametrize=True)
+    # The migration defaults now prefer parametrize-style pytest output,
+    # so a dry-run override is sufficient.
+    cfg = MigrationConfig().with_override(dry_run=True)
 
     res = main.migrate(str(given), cfg)
     # Expect metadata.generated_code mapping to exist and contain one entry

--- a/tests/unit/test_cli_public_api.py
+++ b/tests/unit/test_cli_public_api.py
@@ -15,6 +15,7 @@ def test_create_config_defaults():
     assert cfg.file_patterns == ["test_*.py"]
     # fixture_scope is no longer exposed as a CLI option; ensure config created
     assert hasattr(cfg, "line_length")
+    assert cfg.parametrize is True
 
 
 def test_validate_source_files_with_patterns(tmp_path):

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -9,6 +9,13 @@ def test_create_config_defaults():
     # basic sanity checks on returned MigrationConfig
     assert cfg is not None
     assert hasattr(cfg, "target_directory")
+    assert cfg.parametrize is True
+
+
+def test_create_config_allows_disabling_parametrize():
+    cfg = cli.create_config(parametrize=False)
+
+    assert cfg.parametrize is False
 
 
 def test_validate_source_files_with_patterns(tmp_path: Path):

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -14,6 +14,7 @@ def test_migration_config_creation():
     # Basic defaults
     assert config.line_length == 120
     assert config.preserve_structure is True
+    assert config.parametrize is True
 
 
 def test_migration_config_with_overrides():
@@ -40,6 +41,14 @@ def test_migration_config_to_dict():
 
     assert config_dict["line_length"] == 100
     assert config_dict["preserve_structure"] is True
+
+
+def test_migration_config_from_dict_ignores_legacy_subtest():
+    """Legacy configuration keys such as 'subtest' should be ignored."""
+    config = MigrationConfig.from_dict({"subtest": True, "parametrize": False})
+
+    assert config.parametrize is False
+    assert not hasattr(config, "subtest")
 
 
 def test_pipeline_context_creation():

--- a/tests/unit/test_subtest_parametrize_expanded.py
+++ b/tests/unit/test_subtest_parametrize_expanded.py
@@ -8,10 +8,8 @@ from splurge_unittest_to_pytest.transformers.unittest_transformer import (
 
 
 def _transform(src: str, parametrize: bool = True) -> str:
-    mod = cst.parse_module(src)
     transformer = UnittestToPytestCstTransformer(parametrize=parametrize)
-    new = mod.visit(transformer)
-    return new.code
+    return transformer.transform_code(src)
 
 
 def test_parametrize_with_literal_list():
@@ -47,3 +45,199 @@ def test_parametrize_with_tuple_and_multiple_statements():
     assert "@pytest.mark.parametrize(\"x\", ['a', 'b'])" in out or '@pytest.mark.parametrize("x", ["a", "b"])' in out
     assert "for x in" not in out
     assert "val = x.upper()" in out
+
+
+def test_parametrize_with_tuple_unpacking_and_keywords():
+    src = textwrap.dedent(
+        """
+        import unittest
+
+        class Dummy(unittest.TestCase):
+            def test_integration_workflow(self):
+                test_cases = [
+                    ("123", True, DataType.INTEGER, 123),
+                    ("3.14", True, DataType.FLOAT, 3.14),
+                ]
+
+                for value, can_infer, expected_type, expected_converted in test_cases:
+                    with self.subTest(value=value):
+                        assert self.type_inference.can_infer(value) == can_infer
+                        assert self.type_inference.infer_type(value) == expected_type
+                        assert self.type_inference.convert_value(value) == expected_converted
+        """
+    )
+
+    out = _transform(src)
+    assert (
+        '@pytest.mark.parametrize("value,can_infer,expected_type,expected_converted",' in out
+        or '@pytest.mark.parametrize("value, can_infer, expected_type, expected_converted"' in out
+    )
+    assert "import pytest" in out
+
+
+def test_parametrize_merges_multiple_loops() -> None:
+    src = textwrap.dedent(
+        """
+        import unittest
+
+        class Demo(unittest.TestCase):
+            def test_multi_stage(self):
+                first_batch = [
+                    ("a", 1),
+                    ("b", 2),
+                ]
+
+                second_batch = [
+                    ("c", 3),
+                    ("d", 4),
+                ]
+
+                for value, number in first_batch:
+                    with self.subTest(value=value):
+                        self.assertEqual(len(value), 1)
+                        self.assertLess(number, 10)
+
+                for value, number in second_batch:
+                    with self.subTest(value=value):
+                        self.assertEqual(len(value), 1)
+                        self.assertLess(number, 10)
+        """
+    )
+
+    out = _transform(src)
+
+    assert out.count("@pytest.mark.parametrize") == 1
+    assert "for value, number" not in out
+    assert '("c", 3)' in out
+    assert '("d", 4)' in out
+    assert "subtests.test" not in out
+
+
+def test_parametrize_allows_local_constant_usage() -> None:
+    src = textwrap.dedent(
+        """
+        import unittest
+
+        class Demo(unittest.TestCase):
+            def test_cases(self):
+                size = 3
+                scenarios = [
+                    {
+                        "name": "empty",
+                        "data": [""] * size,
+                    },
+                    {
+                        "name": "none",
+                        "data": [None] * size,
+                    },
+                ]
+
+                for case in scenarios:
+                    with self.subTest(case=case["name"]):
+                        assert len(case["data"]) == size
+        """
+    )
+
+    out = _transform(src)
+
+    assert '@pytest.mark.parametrize("case"' in out
+    assert "with subtests.test" not in out
+    assert "size = 3" in out
+    assert '[""] * 3' in out
+    assert "[None] * 3" in out
+    assert '[""] * size' not in out
+    assert "[None] * size" not in out
+
+
+def test_parametrize_preserves_supporting_assignments() -> None:
+    src = textwrap.dedent(
+        """
+        import unittest
+
+        class Dummy(unittest.TestCase):
+            def test_ordering(self):
+                test_cases = [
+                    ("alpha", 1),
+                    ("beta", 2),
+                ]
+
+                test_size = len(test_cases)
+
+                for label, rank in test_cases:
+                    with self.subTest(label=label):
+                        self.assertLess(rank, test_size)
+        """
+    )
+
+    out = _transform(src)
+
+    assert '@pytest.mark.parametrize("label,rank"' in out or '@pytest.mark.parametrize("label, rank"' in out
+    assert "for label, rank in test_cases" not in out
+    assert "test_size = len(test_cases)" in out
+    assert "test_cases = [" in out
+
+
+def test_parametrize_skips_when_rows_reference_local_names():
+    src = textwrap.dedent(
+        """
+        import unittest
+
+        class Dummy(unittest.TestCase):
+            def compute_size(self):
+                return 3
+
+            def test_derived_data(self):
+                size = self.compute_size()
+                cases = [
+                    ("alpha", [1] * size),
+                    ("beta", [2] * size),
+                ]
+
+                for label, data in cases:
+                    with self.subTest(label=label):
+                        self.assertEqual(len(data), size)
+        """
+    )
+
+    out = _transform(src)
+
+    assert "@pytest.mark.parametrize" not in out
+    assert "subtests.test" in out
+
+
+def test_parametrize_merges_multiple_loops():
+    src = textwrap.dedent(
+        """
+        import unittest
+
+        class Demo(unittest.TestCase):
+            def test_multi_stage(self):
+                first_batch = [
+                    ("a", 1),
+                    ("b", 2),
+                ]
+
+                second_batch = [
+                    ("c", 3),
+                    ("d", 4),
+                ]
+
+                for value, number in first_batch:
+                    with self.subTest(value=value):
+                        self.assertEqual(len(value), 1)
+                        self.assertLess(number, 10)
+
+                for value, number in second_batch:
+                    with self.subTest(value=value):
+                        self.assertEqual(len(value), 1)
+                        self.assertLess(number, 10)
+        """
+    )
+
+    out = _transform(src)
+
+    assert out.count("@pytest.mark.parametrize") == 1
+    assert "for value, number" not in out
+    assert '("c", 3)' in out
+    assert '("d", 4)' in out
+    assert "subtests.test" not in out


### PR DESCRIPTION
- Defaulted migration configuration and CST transformer to enable conservative subTest → pytest.mark.parametrize conversions.
- Removed the internal subtest configuration flag in favor of a single boolean parametrize option while keeping the CLI --subtest switch for compatibility.
- Updated documentation to reflect changes in default behavior and CLI options.
- Refactored transformers to ensure proper handling of subTest loops and their conversion to parametrize.
- Added tests to verify the new default behavior and ensure backward compatibility.
- 
This pull request refactors and simplifies the configuration and CLI interface for controlling subTest-to-parametrize conversions in the unittest-to-pytest migration tool. The changes default to enabling conservative parametrize conversions, remove the internal `subtest` flag in favor of a single `parametrize` boolean, and update the CLI and documentation accordingly. Several tests and documentation examples have also been updated to reflect the new defaults and options.

**Configuration and CLI Simplification:**
* Removed the internal `subtest` configuration flag and now use a single `parametrize` boolean to control subTest-to-parametrize conversions. The CLI now defaults to parametrization and provides `--no-parametrize` and `--subtest` as compatibility flags to disable it. (`splurge_unittest_to_pytest/context.py` [[1]](diffhunk://#diff-77e95fd77220415498b082f291b6778b7b280801632e94957e67da661f92b8f3L99-L105) [[2]](diffhunk://#diff-83828b458dd90b37949feabc8ada16a4f0de9924ad36c7a75046ccc298089781L157-R157) [[3]](diffhunk://#diff-83828b458dd90b37949feabc8ada16a4f0de9924ad36c7a75046ccc298089781L184-R183) [[4]](diffhunk://#diff-83828b458dd90b37949feabc8ada16a4f0de9924ad36c7a75046ccc298089781R198-R199) [[5]](diffhunk://#diff-83828b458dd90b37949feabc8ada16a4f0de9924ad36c7a75046ccc298089781L217-R218) [[6]](diffhunk://#diff-83828b458dd90b37949feabc8ada16a4f0de9924ad36c7a75046ccc298089781L396-L401) [[7]](diffhunk://#diff-83828b458dd90b37949feabc8ada16a4f0de9924ad36c7a75046ccc298089781L449-R446) [[8]](diffhunk://#diff-83828b458dd90b37949feabc8ada16a4f0de9924ad36c7a75046ccc298089781R455-R456) [[9]](diffhunk://#diff-83828b458dd90b37949feabc8ada16a4f0de9924ad36c7a75046ccc298089781L480-R471)
* Updated the transformer and migration logic to use the new `parametrize` flag directly, removing legacy tri-state logic and mutual exclusion checks between `parametrize` and `subtest`. (`splurge_unittest_to_pytest/steps/parse_steps.py` [[1]](diffhunk://#diff-461e5759216ade5e36a938dff60453839bd0c7236f3c89f1f146d51e3fe05661L66-R70) `splurge_unittest_to_pytest/transformers/unittest_transformer.py` [[2]](diffhunk://#diff-a406477bda662099fbd58f79d3a01ea6101cb8ccf36950460f79313620ce646cL259-R259) `splurge_unittest_to_pytest/context.py` [[3]](diffhunk://#diff-77e95fd77220415498b082f291b6778b7b280801632e94957e67da661f92b8f3L404-L415)

**Documentation Updates:**
* Updated documentation and changelog to reflect the new default behavior (parametrize enabled), new CLI options, and how to disable parametrization via CLI or programmatically. (`CHANGELOG.md` [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR13-R18) `docs/README-DETAILS.md` [[2]](diffhunk://#diff-eaaece26412e44100bfab3b49fb7df146af125ec89ffc8e46fd66a90182e6860L85-R85) [[3]](diffhunk://#diff-eaaece26412e44100bfab3b49fb7df146af125ec89ffc8e46fd66a90182e6860L152-R153) [[4]](diffhunk://#diff-eaaece26412e44100bfab3b49fb7df146af125ec89ffc8e46fd66a90182e6860L208-R217)

**Parametrize Conversion Improvements:**
* Improved the subTest-to-parametrize conversion logic to apply recursively, ensuring nested or repeated patterns are fully converted when possible. (`splurge_unittest_to_pytest/transformers/subtest_transformer.py` [splurge_unittest_to_pytest/transformers/subtest_transformer.pyL54-R67](diffhunk://#diff-515dc1e1df2a00348fb71eb68a0d9d129bd19ae2c88c2c3f652166dc26302b2aL54-R67))

**Test and Fixture Updates:**
* Updated and added tests to validate the new default behavior, correct disabling of parametrization, and migration config construction. (`tests/unit/test_cli_utils.py` [[1]](diffhunk://#diff-59df00071355b43efda7f4a4ce48a3399e7d72e55f9393a50cbaee0cad1bd3afR12-R18) `tests/unit/test_cli_public_api.py` [[2]](diffhunk://#diff-0ff06076fee91cfefa85a7ac2f446ed6abb6c675b59e770bf88c4d799e7ac94aR18) `tests/unit/test_context.py` [[3]](diffhunk://#diff-e7bdf02bfc911049993095ca7f5f826842d68fc886d84d5e42c92134ea92875bR17) [[4]](diffhunk://#diff-e7bdf02bfc911049993095ca7f5f826842d68fc886d84d5e42c92134ea92875bR46-R53) `tests/unit/test_subtest_parametrize_expanded.py` [[5]](diffhunk://#diff-bc1c15c6aa89770864571e2a7b2ce491fd86817531a379f2cc60325d81d04834L11-R12) `tests/integration/test_complex_subtest_cases.py` [[6]](diffhunk://#diff-55bd7ab4024f93d5bfdd765fdd1cb606a0419a209200077afa2c55c61b600166L25-R27)

**Golden Output and Example Updates:**
* Updated golden files and examples to reflect the new default of parametrize-style output for subTest conversions. (`tests/data/given_and_expected/pytest_expected_32.txt` [[1]](diffhunk://#diff-5acdf3e767c6711d60d0768072f5330f67efbb01b74d964d8e90b14c7db1f0cbL18-R19) `tests/data/given_and_expected/pytest_expected_40.txt` [[2]](diffhunk://#diff-b0ee47a06932a4f7a9c20dd6c699a8d482f5150320a6df5e77df5d10e5567b08L5-R6) `tests/data/given_and_expected/pytest_expected_42.txt` [[3]](diffhunk://#diff-52274a00d9f7a8cd90cfe652e304b3d2c4c6f405c5c4a8dea9b21d99aa12aed6L7-R8)