### PR TITLE
Chore/prep-for-initial-release

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ splurge-unittest-to-pytest migrate [OPTIONS] [SOURCE_FILES...]
 ```
 
 By default the tool preserves the original source file extensions and will
-write converted output next to the inputs. Use ``-t/--target-dir`` to write to
+write converted output next to the inputs. Use ``-t/--target-root`` to write to
 an alternate location.
 
 ## At-a-glance features

--- a/docs/README-DETAILS.md
+++ b/docs/README-DETAILS.md
@@ -257,7 +257,7 @@ All flags are available on the ``migrate`` command. Summary below; use
 - ``-d, --dir DIR``: Root directory for input discovery.
 - ``-f, --file PATTERN``: Glob pattern(s) to select files (repeatable). Default: ``test_*.py``.
 - ``-r, --recurse / --no-recurse``: Recurse directories (default: recurse).
-- ``-t, --target-dir DIR``: Directory to write outputs.
+- ``-t, --target-root DIR``: Root directory to write outputs.
 - ``--backup-root DIR``: Root directory for backup files when recursing. When specified, backups preserve folder structure. By default, backups are created next to the original files.
 - ``--skip-backup``: Skip creating a ``.backup`` copy of originals when writing (presence-only flag). By default the tool creates a ``.backup`` file next to the original when writing; if a ``.backup`` file already exists it will be preserved and not overwritten.
 - ``--line-length N``: Max line length used by formatters (default: 120).

--- a/docs/specs/technical_specification.md
+++ b/docs/specs/technical_specification.md
@@ -680,7 +680,7 @@ class EventBus:
 class MigrationConfig:
     """Migration behavior configuration."""
     # Output settings
-    target_directory: Optional[str] = None
+    target_root: Optional[str] = None
     preserve_structure: bool = True
     backup_originals: bool = True
     

--- a/examples/api_basic.py
+++ b/examples/api_basic.py
@@ -40,6 +40,7 @@ class TestMath(unittest.TestCase):
         if isinstance(gen, dict):
             # Coerce keys to plain strings (Path objects may be present)
             from pathlib import Path as _P
+
             for k, v in gen.items():
                 try:
                     gen_map[str(_P(k))] = v
@@ -51,6 +52,7 @@ class TestMath(unittest.TestCase):
             path = result.data[0] if isinstance(result.data, list) and result.data else (result.data or "")
             try:
                 from pathlib import Path as _P
+
                 gen_map[str(_P(path))] = gen
             except Exception:
                 gen_map[str(path)] = gen

--- a/scripts/generate_expected_for_new_cases.py
+++ b/scripts/generate_expected_for_new_cases.py
@@ -7,7 +7,7 @@ orchestrator = MigrationOrchestrator()
 
 files = sorted(glob.glob("tests/data/given_and_expected/unittest_given_2*.txt"))
 for f in files:
-    cfg = MigrationConfig(target_directory=".", backup_originals=False)
+    cfg = MigrationConfig(target_root=".", backup_originals=False)
     res = orchestrator.migrate_file(f, cfg)
     out_name = f.replace("unittest_given_", "pytest_expected_")
     if res.is_success():

--- a/scripts/inspect_cst_09.py
+++ b/scripts/inspect_cst_09.py
@@ -4,7 +4,7 @@ from splurge_unittest_to_pytest.context import MigrationConfig
 from splurge_unittest_to_pytest.migration_orchestrator import MigrationOrchestrator
 
 orc = MigrationOrchestrator()
-config = MigrationConfig(target_directory=".", backup_originals=False, dry_run=True)
+config = MigrationConfig(target_root=".", backup_originals=False, dry_run=True)
 res = orc.migrate_file("tests/data/given_and_expected/unittest_given_09.txt", config)
 if not res.is_success():
     print("migration failed", res.error)

--- a/scripts/inspect_transform_09.py
+++ b/scripts/inspect_transform_09.py
@@ -5,7 +5,7 @@ from splurge_unittest_to_pytest.migration_orchestrator import MigrationOrchestra
 
 p = "tests/data/given_and_expected/unittest_given_09.txt"
 orc = MigrationOrchestrator()
-config = MigrationConfig(target_directory=".", backup_originals=False)
+config = MigrationConfig(target_root=".", backup_originals=False)
 res = orc.migrate_file(p, config)
 if res.is_success():
     print(res.data)

--- a/scripts/inspect_transform_09_dry.py
+++ b/scripts/inspect_transform_09_dry.py
@@ -5,7 +5,7 @@ from splurge_unittest_to_pytest.migration_orchestrator import MigrationOrchestra
 
 p = "tests/data/given_and_expected/unittest_given_09.txt"
 orc = MigrationOrchestrator()
-config = MigrationConfig(target_directory=".", backup_originals=False, dry_run=True)
+config = MigrationConfig(target_root=".", backup_originals=False, dry_run=True)
 res = orc.migrate_file(p, config)
 if res.is_success():
     # If dry_run, generated code may be in metadata

--- a/scripts/inspect_try_nodes.py
+++ b/scripts/inspect_try_nodes.py
@@ -4,7 +4,7 @@ from splurge_unittest_to_pytest.context import MigrationConfig
 from splurge_unittest_to_pytest.migration_orchestrator import MigrationOrchestrator
 
 orc = MigrationOrchestrator()
-config = MigrationConfig(target_directory=".", backup_originals=False, dry_run=True)
+config = MigrationConfig(target_root=".", backup_originals=False, dry_run=True)
 res = orc.migrate_file("tests/data/given_and_expected/unittest_given_09.txt", config)
 code = res.metadata.get("generated_code")
 mod = cst.parse_module(code)

--- a/splurge_unittest_to_pytest/cli.py
+++ b/splurge_unittest_to_pytest/cli.py
@@ -30,7 +30,7 @@ from .events import (
 from .pipeline import PipelineFactory
 
 # Initialize typer app
-app = typer.Typer(name="unittest-to-pytest", help="Migrate unittest test suites to pytest format", add_completion=False)
+app = typer.Typer(name="splurge-unittest-to-pytest", help="Migrate unittest test suites to pytest format", add_completion=False)
 
 # Set up logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
@@ -174,7 +174,7 @@ def attach_progress_handlers(event_bus: EventBus, verbose: bool = False) -> None
 
 
 def create_config(
-    target_directory: str | None = None,
+    target_root: str | None = None,
     root_directory: str | None = None,
     file_patterns: list[str] | None = None,
     recurse_directories: bool = True,
@@ -227,7 +227,7 @@ def create_config(
     base = MigrationConfig()
 
     return MigrationConfig(
-        target_directory=target_directory,
+        target_root=target_root,
         root_directory=root_directory,
         file_patterns=file_patterns or base.file_patterns,
         recurse_directories=recurse_directories,
@@ -385,7 +385,7 @@ def migrate(
         ["test_*.py"], "--file", "-f", help="Glob patterns for input files (repeatable)"
     ),
     recurse: bool = typer.Option(True, "--recurse", "-r", help="Recurse directories when searching for files"),
-    target_directory: str | None = typer.Option(None, "--target-dir", "-t", help="Target directory for output files"),
+    target_root: str | None = typer.Option(None, "--target-root", "-t", help="Target root directory for output files"),
     skip_backup: bool = typer.Option(False, "--skip-backup", "-sb", help="Skip backup of original files", is_flag=True),
     backup_root: str | None = typer.Option(
         None, "--backup-root", help="Root directory for backup files (preserves folder structure when recursing)"
@@ -433,7 +433,7 @@ def migrate(
         root_directory: Optional root directory to search when using patterns.
         file_patterns: Glob patterns used to discover input files.
         recurse: Recurse directories when searching for files.
-        target_directory: Directory where converted files will be written.
+        target_root: Root directory where converted files will be written.
         backup_originals: When True create backups of original files prior to overwriting.
         backup_root: Root directory for backup files. When specified, backups preserve folder structure.
         line_length: Maximum line length used by code formatters.
@@ -469,7 +469,7 @@ def migrate(
 
         # Create configuration (decision model always enabled, parametrize always enabled by default)
         config = create_config(
-            target_directory=target_directory,
+            target_root=target_root,
             root_directory=root_directory,
             file_patterns=file_patterns,
             recurse_directories=recurse,
@@ -637,7 +637,7 @@ def init_config(output_file: str = typer.Argument("unittest-to-pytest.yaml", hel
         "# This file contains configuration options for the migration tool.": None,
         "# You can override these settings using command-line flags.": None,
         "# Output settings": None,
-        "target_directory": default_config.get("target_directory"),
+        "target_root": default_config.get("target_root"),
         "backup_originals": default_config.get("backup_originals"),
         "backup_root": default_config.get("backup_root"),
         "# Transformation settings": None,
@@ -670,6 +670,9 @@ def init_config(output_file: str = typer.Argument("unittest-to-pytest.yaml", hel
     except Exception as e:
         logger.error(f"Failed to create configuration file: {e}")
         raise typer.Exit(code=1) from None
+
+
+__all__ = ["create_config", "create_event_bus", "attach_progress_handlers"]
 
 
 def main() -> None:

--- a/splurge_unittest_to_pytest/cli.py
+++ b/splurge_unittest_to_pytest/cli.py
@@ -30,7 +30,9 @@ from .events import (
 from .pipeline import PipelineFactory
 
 # Initialize typer app
-app = typer.Typer(name="splurge-unittest-to-pytest", help="Migrate unittest test suites to pytest format", add_completion=False)
+app = typer.Typer(
+    name="splurge-unittest-to-pytest", help="Migrate unittest test suites to pytest format", add_completion=False
+)
 
 # Set up logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")

--- a/splurge_unittest_to_pytest/context.py
+++ b/splurge_unittest_to_pytest/context.py
@@ -74,7 +74,7 @@ class MigrationConfig:
     """
 
     # Output settings
-    target_directory: str | None = None
+    target_root: str | None = None
     root_directory: str | None = None
     file_patterns: list[str] = field(default_factory=lambda: ["test_*.py"])
     recurse_directories: bool = True

--- a/splurge_unittest_to_pytest/migration_orchestrator.py
+++ b/splurge_unittest_to_pytest/migration_orchestrator.py
@@ -66,7 +66,7 @@ class MigrationOrchestrator:
         if not Path(source_file).exists():
             return Result.failure(FileNotFoundError(f"Source file not found: {source_file}"))
 
-        # Determine target file path. If a target_directory is provided in
+        # Determine target file path. If a target_root is provided in
         # the config, use it while preserving the original filename and
         # extension. Otherwise, let PipelineContext.create compute a default
         # (which preserves the original extension unless overridden by
@@ -74,9 +74,9 @@ class MigrationOrchestrator:
         target_file: str | None = None
         suffix = config.target_suffix if config else ""
 
-        if config and config.target_directory:
+        if config and config.target_root:
             src_path = Path(source_file)
-            dest_dir = Path(config.target_directory)
+            dest_dir = Path(config.target_root)
             dest_dir.mkdir(parents=True, exist_ok=True)
 
             # Determine extension to use (override if provided)

--- a/tests/integration/test_data_driven_final.py
+++ b/tests/integration/test_data_driven_final.py
@@ -86,7 +86,7 @@ class TestDataDrivenTransformation:
             output_file = tmp_path / f"test_{test_num}_output.py"
 
             # Create configuration for initial pipeline run (use tmp_path as output dir)
-            config = create_config(dry_run=False, target_directory=str(tmp_path))
+            config = create_config(dry_run=False, target_root=str(tmp_path))
 
             # Create event bus
             event_bus = create_event_bus()
@@ -112,7 +112,7 @@ class TestDataDrivenTransformation:
             # Create configuration for orchestrator migration
             # Ensure we write outputs to the temporary directory and do not
             # create backups next to the source files in tests/data/given_and_expected.
-            config = MigrationConfig(target_directory=str(tmp_path), backup_originals=False)
+            config = MigrationConfig(target_root=str(tmp_path), backup_originals=False)
 
             # Execute migration
             migration_result = orchestrator.migrate_file(str(given_file), config)

--- a/tests/unit/test_cli_flags.py
+++ b/tests/unit/test_cli_flags.py
@@ -21,7 +21,7 @@ def test_suffix_and_ext_applied(tmp_path: Path):
     write_sample(src)
 
     out_dir = tmp_path / "out"
-    config = cli.create_config(target_directory=str(out_dir), suffix="_migrated", ext="txt")
+    config = cli.create_config(target_root=str(out_dir), suffix="_migrated", ext="txt")
 
     res = main_module.migrate([str(src)], config=config)
     assert res.is_success()
@@ -40,7 +40,7 @@ def test_suffix_sanitization(tmp_path: Path):
 
     out_dir = tmp_path / "out2"
     # Provide a nasty suffix with dots and unsafe chars
-    config = cli.create_config(target_directory=str(out_dir), suffix="..weird..$$$..", ext=None)
+    config = cli.create_config(target_root=str(out_dir), suffix="..weird..$$$..", ext=None)
 
     res = main_module.migrate([str(src)], config=config)
     assert res.is_success()
@@ -55,7 +55,7 @@ def test_ext_normalization_and_invalid(tmp_path: Path):
 
     out_dir = tmp_path / "out3"
     # Provide uppercase ext; expect normalization to lower-case
-    config = cli.create_config(target_directory=str(out_dir), suffix="", ext=".TxT")
+    config = cli.create_config(target_root=str(out_dir), suffix="", ext=".TxT")
 
     res = main_module.migrate([str(src)], config=config)
     assert res.is_success()
@@ -63,7 +63,7 @@ def test_ext_normalization_and_invalid(tmp_path: Path):
     assert written.suffix == ".txt"
 
     # Provide invalid extension -> should be ignored (preserve original)
-    config2 = cli.create_config(target_directory=str(out_dir), suffix="", ext="...!!")
+    config2 = cli.create_config(target_root=str(out_dir), suffix="", ext="...!!")
     res2 = main_module.migrate([str(src)], config=config2)
     assert res2.is_success()
     written2 = Path(res2.data[0])
@@ -75,7 +75,7 @@ def test_suffix_leading_chars(tmp_path: Path):
     write_sample(src)
     out_dir = tmp_path / "out4"
     # Suffix with leading underscore/hyphen should be normalized to single leading underscore
-    config = cli.create_config(target_directory=str(out_dir), suffix="__pref--", ext=None)
+    config = cli.create_config(target_root=str(out_dir), suffix="__pref--", ext=None)
     res = main_module.migrate([str(src)], config=config)
     assert res.is_success()
     written = Path(res.data[0])
@@ -86,7 +86,7 @@ def test_dry_run_returns_path_without_writing(tmp_path: Path):
     src = tmp_path / "dry.py"
     write_sample(src)
     out_dir = tmp_path / "out_dry"
-    config = cli.create_config(target_directory=str(out_dir), suffix="_x", ext=None)
+    config = cli.create_config(target_root=str(out_dir), suffix="_x", ext=None)
     config = config.with_override(dry_run=True)
 
     res = main_module.migrate([str(src)], config=config)

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -8,7 +8,7 @@ def test_create_config_defaults():
     cfg = cli.create_config()
     # basic sanity checks on returned MigrationConfig
     assert cfg is not None
-    assert hasattr(cfg, "target_directory")
+    assert hasattr(cfg, "target_root")
     assert cfg.enable_decision_analysis is True
 
 


### PR DESCRIPTION
This pull request standardizes the naming of the output directory configuration option throughout the codebase by renaming `target_directory` to `target_root`. This affects the CLI, configuration objects, documentation, and all related usages. The update improves clarity and consistency for users and developers, and ensures all references to the output directory are aligned across the project.

### Configuration and API changes

* Renamed the `MigrationConfig` attribute from `target_directory` to `target_root` in `splurge_unittest_to_pytest/context.py`, `docs/specs/technical_specification.md`, and all scripts and tests that instantiate `MigrationConfig`. [[1]](diffhunk://#diff-77e95fd77220415498b082f291b6778b7b280801632e94957e67da661f92b8f3L77-R77) [[2]](diffhunk://#diff-d9f3476322fa56355fbea1a5d673f22a90e8174b63249aaa3686ea8966558ab7L683-R683) [[3]](diffhunk://#diff-4e11cccaa3bf902e2781539297a1a44c7cfc6c604f570d908061a371824cc7c9L10-R10) [[4]](diffhunk://#diff-89407e7d03ab8983dfed5e27f6dc04e10ac581e9f3dcee45b2e0b3f8a1aa13dbL7-R7) [[5]](diffhunk://#diff-43971e2562a75057d96c2885d961c056159611a594dad09b663e954474637eb0L8-R8) [[6]](diffhunk://#diff-a47864be6fc86d279b3175cbd3e7c1471ae078b6ec42807b88402370efe184d7L8-R8) [[7]](diffhunk://#diff-25269f5b47472529c6230f713110245b16080f9150de238098a2c3bfe609f669L7-R7) [[8]](diffhunk://#diff-77a888ff5c5fa8a898f73a4df4cb1b5b062eaca890f593084f60fd70624d56a4L115-R115)
* Updated the CLI option and help text from `--target-dir` to `--target-root` in `splurge_unittest_to_pytest/cli.py`, including all references in function signatures, documentation strings, and the configuration initializer. [[1]](diffhunk://#diff-83828b458dd90b37949feabc8ada16a4f0de9924ad36c7a75046ccc298089781L388-R390) [[2]](diffhunk://#diff-83828b458dd90b37949feabc8ada16a4f0de9924ad36c7a75046ccc298089781L436-R438) [[3]](diffhunk://#diff-83828b458dd90b37949feabc8ada16a4f0de9924ad36c7a75046ccc298089781L472-R474) [[4]](diffhunk://#diff-83828b458dd90b37949feabc8ada16a4f0de9924ad36c7a75046ccc298089781L640-R642)
* Changed internal logic to use `target_root` instead of `target_directory` when determining output file paths in `splurge_unittest_to_pytest/migration_orchestrator.py`.

### Documentation updates

* Updated documentation and README files to reflect the new naming (`target_root`) for the output directory configuration option, replacing all instances of `target_directory`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L36-R36) [[2]](diffhunk://#diff-eaaece26412e44100bfab3b49fb7df146af125ec89ffc8e46fd66a90182e6860L260-R260)

### Test and example updates

* Refactored all tests and example scripts to use `target_root` in place of `target_directory` when creating migration configs, ensuring consistency and proper test coverage for the new naming. [[1]](diffhunk://#diff-a0d0e2e52e7dc98051466b0fb10fbc6891c2c014c964de159e6c688f76aa376eL24-R24) [[2]](diffhunk://#diff-a0d0e2e52e7dc98051466b0fb10fbc6891c2c014c964de159e6c688f76aa376eL43-R43) [[3]](diffhunk://#diff-a0d0e2e52e7dc98051466b0fb10fbc6891c2c014c964de159e6c688f76aa376eL58-R66) [[4]](diffhunk://#diff-a0d0e2e52e7dc98051466b0fb10fbc6891c2c014c964de159e6c688f76aa376eL78-R78) [[5]](diffhunk://#diff-a0d0e2e52e7dc98051466b0fb10fbc6891c2c014c964de159e6c688f76aa376eL89-R89) [[6]](diffhunk://#diff-59df00071355b43efda7f4a4ce48a3399e7d72e55f9393a50cbaee0cad1bd3afL11-R11) [[7]](diffhunk://#diff-77a888ff5c5fa8a898f73a4df4cb1b5b062eaca890f593084f60fd70624d56a4L89-R89)

### Minor improvements

* Added `__all__` declaration to `splurge_unittest_to_pytest/cli.py` for explicit module exports.
* Improved key coercion logic in `examples/api_basic.py` for generated code output, ensuring compatibility with various path types.