### PR TITLE
Fix/cleanup-issues

### DIFF
--- a/docs/README-DETAILS.md
+++ b/docs/README-DETAILS.md
@@ -320,6 +320,7 @@ All flags are available on the ``migrate`` command. Summary below; use
 
 ## Advanced Options
 - ``--source-map``: Create source mapping for debugging transformations (advanced users) (presence-only flag).
+- ``--max-depth``: Maximum depth to traverse nested control flow structures (3-15, default: 7). Controls how deeply the transformer explores nested control flow blocks (try/except/else/finally, with, if/else, for/else, while/else) when processing assertions.
 
 YAML Configuration File Format
 -------------------------------
@@ -388,6 +389,7 @@ report_format: "json"
 
 # Advanced Options
 create_source_map: false
+max_depth: 7
 ```
 
 ### Configuration File Usage

--- a/splurge_unittest_to_pytest/cli.py
+++ b/splurge_unittest_to_pytest/cli.py
@@ -672,6 +672,9 @@ def migrate(
     create_source_map: bool = typer.Option(
         False, "--source-map", help="Create source mapping for debugging transformations (advanced users)", is_flag=True
     ),
+    max_depth: int = typer.Option(
+        7, "--max-depth", help="Maximum depth to traverse nested control flow structures (3-15, default: 7)"
+    ),
 ) -> None:
     """Migrate unittest files to pytest format with comprehensive configuration options.
 
@@ -842,6 +845,7 @@ def migrate(
     config_kwargs["cache_analysis_results"] = final_cache_analysis
     config_kwargs["preserve_file_encoding"] = final_preserve_encoding
     config_kwargs["create_source_map"] = create_source_map
+    config_kwargs["max_depth"] = max_depth
 
     config = base_config.with_override(**config_kwargs)
 
@@ -1047,6 +1051,7 @@ def init_config(output_file: str = typer.Argument("unittest-to-pytest.yaml", hel
         "# Advanced options": None,
         "preserve_file_encoding": default_config.get("preserve_file_encoding"),
         "create_source_map": default_config.get("create_source_map"),
+        "max_depth": default_config.get("max_depth"),
         "# Degradation settings": None,
         "degradation_enabled": default_config.get("degradation_enabled"),
         "degradation_tier": default_config.get("degradation_tier"),

--- a/splurge_unittest_to_pytest/config_validation.py
+++ b/splurge_unittest_to_pytest/config_validation.py
@@ -81,6 +81,9 @@ class ValidatedMigrationConfig(BaseModel):
     # Advanced options
     preserve_file_encoding: bool = Field(default=True, description="Whether to preserve original file encoding")
     create_source_map: bool = Field(default=False, description="Whether to create source mapping for debugging")
+    max_depth: int = Field(
+        default=7, ge=3, le=15, description="Maximum depth to traverse nested control flow structures"
+    )
 
     # Test method patterns
     test_method_prefixes: list[str] = Field(

--- a/splurge_unittest_to_pytest/context.py
+++ b/splurge_unittest_to_pytest/context.py
@@ -169,6 +169,8 @@ class MigrationConfig:
     """Whether to preserve original file encoding when writing output"""
     create_source_map: bool = False
     """Whether to create source mapping for debugging transformations"""
+    max_depth: int = 7
+    """Maximum depth to traverse when processing nested control flow structures (3-15)"""
 
     def with_override(self, **kwargs: Any) -> "MigrationConfig":
         """Return a new ``MigrationConfig`` with specified overrides.

--- a/splurge_unittest_to_pytest/events.py
+++ b/splurge_unittest_to_pytest/events.py
@@ -304,6 +304,8 @@ class LoggingSubscriber(EventSubscriber):
         """
         self.event_bus.subscribe(PipelineStartedEvent, self._on_pipeline_started)
         self.event_bus.subscribe(PipelineCompletedEvent, self._on_pipeline_completed)
+        self.event_bus.subscribe(JobStartedEvent, self._on_job_started)
+        self.event_bus.subscribe(JobCompletedEvent, self._on_job_completed)
         self.event_bus.subscribe(StepStartedEvent, self._on_step_started)
         self.event_bus.subscribe(StepCompletedEvent, self._on_step_completed)
         self.event_bus.subscribe(ErrorEvent, self._on_error)
@@ -315,6 +317,8 @@ class LoggingSubscriber(EventSubscriber):
         """
         self.event_bus.unsubscribe(PipelineStartedEvent, self._on_pipeline_started)
         self.event_bus.unsubscribe(PipelineCompletedEvent, self._on_pipeline_completed)
+        self.event_bus.unsubscribe(JobStartedEvent, self._on_job_started)
+        self.event_bus.unsubscribe(JobCompletedEvent, self._on_job_completed)
         self.event_bus.unsubscribe(StepStartedEvent, self._on_step_started)
         self.event_bus.unsubscribe(StepCompletedEvent, self._on_step_completed)
         self.event_bus.unsubscribe(ErrorEvent, self._on_error)
@@ -351,6 +355,21 @@ class LoggingSubscriber(EventSubscriber):
         """
         status = event.result.status.value.upper()
         self.event_bus._logger.debug(f"Step completed in {event.duration_ms:.2f}ms: {event.step_name} ({status})")
+
+    def _on_job_started(self, event: JobStartedEvent) -> None:
+        """Handle job started event.
+
+        Logs a debug message that includes the job name and task count.
+        """
+        self.event_bus._logger.debug(f"Job started: {event.job_name} ({event.task_count} tasks)")
+
+    def _on_job_completed(self, event: JobCompletedEvent) -> None:
+        """Handle job completed event.
+
+        Logs the job duration and status at debug level.
+        """
+        status = event.final_result.status.value.upper()
+        self.event_bus._logger.debug(f"Job completed in {event.duration_ms:.2f}ms: {event.job_name} ({status})")
 
     def _on_error(self, event: ErrorEvent) -> None:
         """Handle error event.

--- a/splurge_unittest_to_pytest/transformers/assert_transformer.py
+++ b/splurge_unittest_to_pytest/transformers/assert_transformer.py
@@ -1768,7 +1768,13 @@ def _process_try_statement(stmt: cst.BaseStatement) -> cst.BaseStatement | None:
         # Process the try body
         try_body = getattr(stmt, "body", None)
         if try_body is not None and hasattr(try_body, "body"):
-            new_try_body = try_body.with_changes(body=wrap_assert_in_block(list(try_body.body)))
+            # try_body.body should be a tuple/list of statements
+            body_statements = try_body.body
+            if isinstance(body_statements, list | tuple):
+                new_try_body = try_body.with_changes(body=wrap_assert_in_block(list(body_statements)))
+            else:
+                # If it's not a list/tuple, keep as is
+                new_try_body = try_body
         else:
             new_try_body = try_body
 
@@ -1777,8 +1783,13 @@ def _process_try_statement(stmt: cst.BaseStatement) -> cst.BaseStatement | None:
         for h in getattr(stmt, "handlers", []) or []:
             h_body = getattr(h, "body", None)
             if h_body is not None and hasattr(h_body, "body"):
-                new_h_body = h_body.with_changes(body=wrap_assert_in_block(list(h_body.body)))
-                new_h = h.with_changes(body=new_h_body)
+                # h_body.body should be a tuple/list of statements
+                body_statements = h_body.body
+                if isinstance(body_statements, list | tuple):
+                    new_h_body = h_body.with_changes(body=wrap_assert_in_block(list(body_statements)))
+                    new_h = h.with_changes(body=new_h_body)
+                else:
+                    new_h = h
             else:
                 new_h = h
             new_handlers.append(new_h)
@@ -1786,12 +1797,18 @@ def _process_try_statement(stmt: cst.BaseStatement) -> cst.BaseStatement | None:
         # Process orelse
         new_orelse = getattr(stmt, "orelse", None)
         if new_orelse is not None and hasattr(new_orelse, "body"):
-            new_orelse = new_orelse.with_changes(body=wrap_assert_in_block(list(new_orelse.body)))
+            # new_orelse.body should be a tuple/list of statements
+            body_statements = new_orelse.body
+            if isinstance(body_statements, list | tuple):
+                new_orelse = new_orelse.with_changes(body=wrap_assert_in_block(list(body_statements)))
 
         # Process finalbody
         new_finalbody = getattr(stmt, "finalbody", None)
         if new_finalbody is not None and hasattr(new_finalbody, "body"):
-            new_finalbody = new_finalbody.with_changes(body=wrap_assert_in_block(list(new_finalbody.body)))
+            # new_finalbody.body should be a tuple/list of statements
+            body_statements = new_finalbody.body
+            if isinstance(body_statements, list | tuple):
+                new_finalbody = new_finalbody.with_changes(body=wrap_assert_in_block(list(body_statements)))
 
         # Build new Try node with updated blocks
         new_try = stmt.with_changes(

--- a/splurge_unittest_to_pytest/transformers/unittest_transformer.py
+++ b/splurge_unittest_to_pytest/transformers/unittest_transformer.py
@@ -641,7 +641,8 @@ class UnittestToPytestCstTransformer(cst.CSTTransformer):
                 continue
 
             try:
-                wrapped_nodes = wrap_assert_in_block([node])
+                max_depth = getattr(self.config, "max_depth", 7) if self.config else 7
+                wrapped_nodes = wrap_assert_in_block([node], max_depth)
                 rewritten.extend(wrapped_nodes)
             except (AttributeError, TypeError, ValueError):
                 # Assert wrapping failed, keep original
@@ -1124,7 +1125,8 @@ class UnittestToPytestCstTransformer(cst.CSTTransformer):
             node = self._rewrite_function_decorators(node)
             node, body_statements = self._convert_simple_subtests(original_node, node)
             try:
-                wrapped_body = wrap_assert_in_block(body_statements)
+                max_depth = getattr(self.config, "max_depth", 7) if self.config else 7
+                wrapped_body = wrap_assert_in_block(body_statements, max_depth)
             except (AttributeError, TypeError, ValueError):
                 wrapped_body = body_statements
             node = node.with_changes(body=node.body.with_changes(body=wrapped_body))

--- a/tests/data/complex_nesting/deeply_nested_control_flow.txt
+++ b/tests/data/complex_nesting/deeply_nested_control_flow.txt
@@ -1,0 +1,98 @@
+import unittest
+from unittest.mock import Mock, patch
+
+
+class TestDeeplyNestedControlFlow(unittest.TestCase):
+    """Test case with deeply nested control flow structures to validate AST transformation robustness."""
+
+    def setUp(self):
+        self.mock_conn = Mock()
+        self.mock_something = Mock()
+
+    def test_deeply_nested_try_with_assert(self):
+        """Test with try -> try -> with -> try -> with -> assert nesting."""
+        try:
+            # First level try
+            try:
+                # Second level try
+                with self.mock_conn as conn:
+                    # With block containing try
+                    try:
+                        # Third level try
+                        with self.mock_something as something:
+                            # Deepest with block with assert
+                            assert something.is_valid()
+                            assert conn.is_connected()
+                    except ValueError:
+                        # Exception handler in deepest try
+                        pass
+            except ConnectionError:
+                # Exception handler in second try
+                pass
+        except Exception:
+            # Exception handler in outermost try
+            pass
+
+        # Verification outside the nested structure
+        self.mock_conn.__enter__.assert_called_once()
+        self.mock_something.__enter__.assert_called_once()
+
+    def test_mixed_nesting_patterns(self):
+        """Test various nesting patterns to ensure robustness."""
+        # Pattern: try -> with -> try -> with -> assert
+        try:
+            with self.mock_conn:
+                try:
+                    with self.mock_something:
+                        assert True
+                        assert 1 + 1 == 2
+                except AssertionError:
+                    pass
+        except Exception:
+            pass
+
+        # Pattern: with -> try -> with -> try -> assert
+        with self.mock_conn:
+            try:
+                with self.mock_something:
+                    try:
+                        assert False, "This should not fail the test"
+                    except AssertionError:
+                        pass  # Expected to catch the assertion
+            except Exception:
+                pass
+
+    def test_complex_error_handling_nesting(self):
+        """Test complex error handling with deep nesting."""
+        try:
+            try:
+                with self.mock_conn as conn:
+                    try:
+                        with self.mock_something as something:
+                            try:
+                                # Simulate an operation that might fail
+                                if not conn.is_connected():
+                                    raise ConnectionError("Not connected")
+                                if not something.is_ready():
+                                    raise ValueError("Not ready")
+                                assert conn.process_data(something.get_data())
+                            except ValueError as ve:
+                                # Handle ValueError in innermost try
+                                print(f"Value error: {ve}")
+                                raise
+                            except AssertionError as ae:
+                                # Handle AssertionError in innermost try
+                                print(f"Assertion error: {ae}")
+                                raise
+                    except ValueError:
+                        # Handle ValueError from inner with
+                        pass
+                    except AssertionError:
+                        # Handle AssertionError from inner with
+                        pass
+            except ConnectionError:
+                # Handle ConnectionError from outer with
+                pass
+        except Exception:
+            # Handle any remaining exceptions
+            pass

--- a/tests/unit/test_deeply_nested_control_flow.py
+++ b/tests/unit/test_deeply_nested_control_flow.py
@@ -1,0 +1,115 @@
+"""Test cases for deeply nested control flow structures."""
+
+from pathlib import Path
+
+import pytest
+
+from splurge_unittest_to_pytest.transformers.unittest_transformer import UnittestToPytestCstTransformer
+
+
+class TestDeeplyNestedControlFlow:
+    """Test transformation of deeply nested control flow structures."""
+
+    def test_deeply_nested_try_with_blocks(self):
+        """Test that deeply nested try/with blocks with asserts can be processed without errors."""
+        test_file = Path(__file__).parent.parent / "data" / "complex_nesting" / "deeply_nested_control_flow.txt"
+
+        # Read the test file
+        with open(test_file, encoding="utf-8") as f:
+            source_code = f.read()
+
+        # Create transformer
+        transformer = UnittestToPytestCstTransformer()
+
+        # This should not raise any exceptions, even with the complex nesting
+        result = transformer.transform_code(source_code)
+
+        # Verify we got some result (transformation may or may not change the code,
+        # but it should complete without errors)
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+        # Verify the basic structure is preserved (transformed imports, class definition, method names)
+        assert "from unittest.mock import Mock, patch" in result
+        assert "import pytest" in result
+        assert "class TestDeeplyNestedControlFlow" in result
+        assert "def test_deeply_nested_try_with_assert" in result
+        assert "def test_mixed_nesting_patterns" in result
+        assert "def test_complex_error_handling_nesting" in result
+
+        # Verify that the deeply nested structure didn't break the transformation
+        assert "try:" in result  # Should still have try blocks
+        assert "with " in result  # Should still have with blocks
+        assert "assert " in result  # Should still have assert statements
+
+    def test_extremely_deep_nesting_robustness(self):
+        """Test that the _safe_extract_statements function handles pathological cases."""
+        from splurge_unittest_to_pytest.transformers.assert_transformer import _safe_extract_statements
+
+        # Test with None input
+        assert _safe_extract_statements(None) is None
+
+        # Test with object that doesn't have body attribute
+        class MockObject:
+            pass
+
+        assert _safe_extract_statements(MockObject()) is None
+
+        # Test with object that has body but it's not a list/tuple
+        class MockIndentedBlock:
+            def __init__(self, body):
+                self.body = body
+
+        # Test with string body (should return None)
+        mock_block = MockIndentedBlock("not a list")
+        assert _safe_extract_statements(mock_block) is None
+
+        # Test with deeply nested structure (simulating pathological case)
+        deep_block = MockIndentedBlock(MockIndentedBlock(MockIndentedBlock([1, 2, 3])))
+        result = _safe_extract_statements(deep_block)
+        assert result == [1, 2, 3]
+
+        # Test with too deeply nested structure (should hit max_depth)
+        too_deep = MockIndentedBlock(None)
+        current = too_deep
+        for _i in range(10):  # Create 10 levels deep
+            current.body = MockIndentedBlock(None)
+            current = current.body
+
+        # This should return None due to hitting max_depth
+        result = _safe_extract_statements(too_deep)
+        assert result is None
+
+    def test_cli_processing_of_complex_file(self, tmp_path):
+        """Test that the CLI can process the complex nesting file without errors."""
+        import subprocess
+        import sys
+        from pathlib import Path
+
+        # Get the path to the complex test file
+        complex_file = Path(__file__).parent.parent / "data" / "complex_nesting" / "deeply_nested_control_flow.txt"
+
+        # Run the CLI command with dry-run to avoid file I/O issues in test
+        cmd = [
+            sys.executable,
+            "-m",
+            "splurge_unittest_to_pytest.cli",
+            "migrate",
+            "--dry-run",
+            "--verbose",
+            str(complex_file),
+        ]
+
+        result = subprocess.run(cmd, capture_output=True, text=True, cwd=Path.cwd())
+
+        # The command should succeed (exit code 0)
+        assert result.returncode == 0, f"CLI failed with stderr: {result.stderr}"
+
+        # Should see the pipeline and job completion messages
+        assert "Starting migration pipeline:" in result.stdout
+        assert "[SUCCESS] Migration completed successfully:" in result.stdout
+
+        # Should contain the transformed output in dry-run mode
+        assert "from unittest.mock import Mock, patch" in result.stdout
+        assert "import pytest" in result.stdout
+        assert "class TestDeeplyNestedControlFlow" in result.stdout

--- a/tests/unit/test_nested_loops_and_if.py
+++ b/tests/unit/test_nested_loops_and_if.py
@@ -1,0 +1,62 @@
+"""Tests for nested If/For/While control flow handling in the transformer."""
+
+from splurge_unittest_to_pytest.transformers.unittest_transformer import (
+    UnittestToPytestCstTransformer,
+)
+
+
+class TestNestedIfForWhile:
+    def test_nested_if_for_while_processing(self) -> None:
+        """Ensure asserts inside nested If/For/While are transformed and recursion occurs."""
+        source = (
+            "import unittest\n\n"
+            "class T(unittest.TestCase):\n"
+            "    def test_nested(self):\n"
+            "        for i in range(2):\n"
+            "            if i % 2 == 0:\n"
+            "                while i < 1:\n"
+            "                    self.assertTrue(i == 0)\n"
+            "            else:\n"
+            "                for j in range(1):\n"
+            "                    self.assertEqual(j + 1, 1)\n"
+            "        else:\n"
+            "            self.assertFalse(False)\n"
+        )
+
+        transformer = UnittestToPytestCstTransformer()
+        result = transformer.transform_code(source)
+
+        assert isinstance(result, str) and result
+        # Core expectations: unittest import removed, assertions rewritten, structure preserved
+        assert "import unittest" not in result
+        assert "assert " in result
+        assert "for i in range(2):" in result
+        assert "while i < 1:" in result
+        assert "if i % 2 == 0:" in result
+        assert "else:" in result
+        # Ensure original unittest-style asserts are gone
+        assert "self.assertTrue" not in result
+        assert "self.assertEqual" not in result
+        assert "self.assertFalse" not in result
+
+    def test_loop_orelse_with_assert_raises(self) -> None:
+        """Ensure loop orelse bodies are processed and with-assertRaises is rewritten."""
+        source = (
+            "import unittest\n\n"
+            "class T(unittest.TestCase):\n"
+            "    def test_for_else_raises(self):\n"
+            "        for x in []:\n"
+            "            pass\n"
+            "        else:\n"
+            "            with self.assertRaises(ValueError):\n"
+            "                raise ValueError('x')\n"
+        )
+
+        transformer = UnittestToPytestCstTransformer()
+        result = transformer.transform_code(source)
+
+        assert isinstance(result, str) and result
+        # Expect the with self.assertRaises to be converted to pytest.raises in loop orelse
+        assert "with pytest.raises(ValueError" in result
+        # Ensure unittest import is removed
+        assert "import unittest" not in result


### PR DESCRIPTION
Introduced a new `--max-depth` command-line option and corresponding configuration setting to control the maximum depth of nested control flow structures during transformation. This enhancement allows users to specify a depth range (3-15, default: 7) for traversing nested blocks, improving the robustness of the migration tool. Updated relevant documentation and tests to reflect this new feature, ensuring comprehensive coverage and validation of deeply nested structures.