### PR TITLE
Chore/improvement plan

### DIFF
--- a/.cursor/rules/python-standards.mdc
+++ b/.cursor/rules/python-standards.mdc
@@ -5,7 +5,7 @@ alwaysApply: false
 - Always add type annotations to function and method signatures.
 - Add type annotations to variables when it improves code clarity.
 - Prefer | instead of Optional or Union.
-- Code concise, technical, Python that adheres to PEP 8 and PEP 585.
+- Code concise, technical, Python that adheres to PEP 8, PEP 604, and PEP 585.
 - Code to modern Python standards targeting version 3.10 or later.
 - Use absolute import paths.
 - When possible, place imports at top of module.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -66,7 +66,7 @@ This document contains coding standards and guidelines for the splurge-ai-rules 
 - Always add type annotations to function and method signatures.
 - Add type annotations to variables when it improves code clarity.
 - Prefer | instead of Optional or Union.
-- Code concise, technical, Python that adheres to PEP 8 and PEP 585.
+- Code concise, technical, Python that adheres to PEP 8, PEP 604, and PEP 585.
 - Code to modern Python standards targeting version 3.10 or later.
 - Use absolute import paths, where appropriate.
 - When possible, place imports at top of module.

--- a/.github/workflows/pr-debug-tests.yml
+++ b/.github/workflows/pr-debug-tests.yml
@@ -1,0 +1,35 @@
+name: PR — debug tests
+
+on:
+  pull_request: {}
+
+permissions:
+  contents: read
+
+jobs:
+  debug-tests:
+    name: Run tests with SPLURGE_TRANSFORM_DEBUG
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.13"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # Prefer installing from pyproject.toml using editable install and the 'dev' extras.
+          pip install -e .[dev] || pip install "-r" requirements.txt || true
+
+      - name: Run tests (debug mode)
+        env:
+          SPLURGE_TRANSFORM_DEBUG: '1'
+        run: |
+          pytest -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,13 @@
  - Added additional unit tests for path utilities:
     - `tests/unit/test_path_utils_basic.py` (basic validation and ensure_parent_dir)
     - `tests/unit/test_path_utils_edgecases.py` (empty path, invalid chars, Windows long-path, permission error simulation)
+- Added parametrize decorator helper factory and tests:
+	- `splurge_unittest_to_pytest.transformers.parametrize_helper._make_parametrize_call` for centralized decorator construction
+	- `tests/unit/test_parametrize_decorator_helper.py` (basic decorator creation and ids kwarg handling)
 
 ### Changed
 - `splurge_unittest_to_pytest.transformers.assert_transformer` now delegates caplog-related behavior to `_caplog_helpers` and re-exports thin compatibility shims to preserve public APIs.
+- `splurge_unittest_to_pytest.transformers.parametrize_helper` now delegates parametrize decorator construction to a centralized `_make_parametrize_call` helper to improve testability and consistency.
 
 ### Notes
 - Full test-suite run: 945 passed locally. Recommend enabling a CI job that runs the suite once with `SPLURGE_TRANSFORM_DEBUG=1` for PR verification.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Added unit tests:
 	- `tests/unit/test_caplog_helpers_basic.py` for caplog helper behavior.
 	- `tests/unit/test_debug_gate_basic.py` for debug gate behavior.
+ - Added additional unit tests for path utilities:
+    - `tests/unit/test_path_utils_basic.py` (basic validation and ensure_parent_dir)
+    - `tests/unit/test_path_utils_edgecases.py` (empty path, invalid chars, Windows long-path, permission error simulation)
 
 ### Changed
 - `splurge_unittest_to_pytest.transformers.assert_transformer` now delegates caplog-related behavior to `_caplog_helpers` and re-exports thin compatibility shims to preserve public APIs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
-(# Changelog)
+# Changelog
 
-All notable changes to this project will be documented in this file.
+## Unreleased (chore/improvement-plan)
+
+### Added
+- Extracted caplog alias detection and AST construction into `splurge_unittest_to_pytest.transformers._caplog_helpers`.
+- Added `splurge_unittest_to_pytest.transformers.debug` for `SPLURGE_TRANSFORM_DEBUG` debug gating and a `maybe_reraise` helper.
+- Added unit tests:
+	- `tests/unit/test_caplog_helpers_basic.py` for caplog helper behavior.
+	- `tests/unit/test_debug_gate_basic.py` for debug gate behavior.
+
+### Changed
+- `splurge_unittest_to_pytest.transformers.assert_transformer` now delegates caplog-related behavior to `_caplog_helpers` and re-exports thin compatibility shims to preserve public APIs.
+
+### Notes
+- Full test-suite run: 945 passed locally. Recommend enabling a CI job that runs the suite once with `SPLURGE_TRANSFORM_DEBUG=1` for PR verification.
 
 ## [2025.0.4] 2025-10-03
 

--- a/docs/plans/plan-improvements-implementation-2025-10-03.md
+++ b/docs/plans/plan-improvements-implementation-2025-10-03.md
@@ -1,0 +1,181 @@
+# Implementation Plan: Improvements Roadmap
+
+Date: 2025-10-03
+Author: automated review assistant (paired)
+
+This document is a concrete implementation plan for the prioritized refactors and robustness improvements recommended in
+`docs/research/research-opportunities-for-improvements-2025-10-03.md`.
+
+Goals
+- Reduce module complexity and duplication.
+- Improve observability of transformation failures during development and CI.
+- Separate pure validation from side-effects for IO helpers.
+- Harden parametrize conversion heuristics and make them easier to test.
+
+How to read this file
+- Priorities are grouped into High, Medium-High, Medium, Low.
+- Each priority is split into Stages and Tasks.
+- Each Task contains: Scope, Specifications / Contracts, Acceptance Criteria, Implementation Notes, and Tests.
+
+
+## High Priority
+
+Rationale: Low-risk, high-value changes that reduce duplication and improve debugability. These are quick wins with strong ROI.
+
+### Stage 1: Extract caplog helpers (very low risk)
+
+Task 1.1 - Create `transformers/_caplog_helpers.py`
+- Scope: Add a small helper module exposing functions to detect and rewrite caplog-related AST patterns and to build caplog expression fragments used by multiple transformers.
+- Files to create/update:
+  - `splurge_unittest_to_pytest/transformers/_caplog_helpers.py` (new)
+  - `splurge_unittest_to_pytest/transformers/assert_transformer.py` (update imports + replace duplicated code)
+- Contract:
+  - Inputs: a `libcst.CSTNode` representing an expression or statement.
+  - Outputs: typed libcst nodes or dataclasses describing the alias access (example dataclass `AliasOutputAccess(alias: str, slice: Optional[cst.BaseExpression])`).
+  - Error behavior: return `None` if the shape is not recognized; do not raise for unexpected inputs.
+- Acceptance criteria:
+  - All existing behaviour for caplog handling remains unchanged as validated by unit tests and full test-suite.
+  - No duplication remains in `assert_transformer.py` for caplog alias detection; tests for the moved helpers exist.
+- Implementation notes:
+  - Keep API minimal: `extract_alias_output_slices(node) -> AliasOutputAccess | None`, `build_caplog_records_expr(access) -> cst.BaseExpression`, `build_get_message_call(access) -> cst.Call`.
+- Tests:
+  - Unit tests for 6 representative AST patterns (plain attribute, subscripted, alias with asname, nested attribute) asserting expected returned structure and generated code.
+
+Task 1.2 - Update `assert_transformer.py` to use helpers
+- Scope: Replace duplicated code sections that detect alias.output slices and build caplog AST with calls to `_caplog_helpers`.
+- Acceptance criteria:
+  - Code compiles and tests pass.
+  - Diff is small and reviewers can easily see logic moved vs changed.
+
+
+### Stage 2: Add TRANSFORM_DEBUG and improve error surfacing (low risk)
+
+Task 2.1 - Add a small debug gate
+- Scope: Add a module-level helper `transformers/debug.py` or a small utility function in `transformer_helper.py` that reads `SPLURGE_TRANSFORM_DEBUG` env var.
+- Contract:
+  - `get_transform_debug() -> bool` reads `os.getenv("SPLURGE_TRANSFORM_DEBUG", "") in {"1","true","True"}`.
+  - A helper `maybe_reraise(exc: Exception)` will re-raise when debug is enabled; otherwise will optionally log.
+- Acceptance criteria:
+  - When `SPLURGE_TRANSFORM_DEBUG=1` and a transform helper encounters an unexpected exception, the exception is re-raised (tests should demonstrate this using a small injected failure).
+  - Default behaviour remains silent/conservative to preserve existing safety in non-debug mode.
+- Implementation notes:
+  - Place usage points in: `record_replacement`, `_apply_recorded_replacements`, and top-level transform invocation `transform_code` where we catch broad exceptions.
+- Tests:
+  - Unit test that sets env var and asserts that a deliberately broken helper raises; counterpart test asserts no raise in default mode.
+
+
+## Medium-High Priority
+
+Rationale: Slightly more invasive but still contained refactors that improve testability and reduce surprise side-effects.
+
+### Stage 1: Make `helpers/path_utils.validate_target_path` pure (low risk)
+
+Task 3.1 - Separate validation from side-effects
+- Scope:
+  - Update `helpers/path_utils.py` to split `validate_target_path` into two functions:
+    - `validate_target_path(path: str | Path, allow_long_paths: bool = False) -> Path` (pure validation)
+    - `ensure_parent_dir(path: str | Path, exist_ok: bool = True) -> None` (side-effects)
+- Specifications / Contracts:
+  - `validate_target_path` must not create directories or modify FS.
+  - It returns a `Path` instance or raises `ValueError`/`PermissionError` on invalid conditions.
+  - Writability check should be implemented via a small attempt to create a temporary file in the parent directory (os.open with O_CREAT|O_EXCL) and immediately remove it — this is more reliable than `os.access` on Windows.
+  - `ensure_parent_dir` performs `Path(path).parent.mkdir(parents=True, exist_ok=exist_ok)` and raises on failure.
+- Acceptance criteria:
+  - All call sites are updated to call `ensure_parent_dir` where they previously relied on `validate_target_path` side-effects.
+  - Tests cover both functions using `tmp_path` fixtures and assert behavior on unwritable directories (using pytest's `monkeypatch` to simulate PermissionError where necessary).
+- Backwards compatibility notes:
+  - If any public API expected `validate_target_path` to create parents, update its callers in the CLI and script entrypoints.
+- Tests:
+  - Unit tests for `validate_target_path` returning valid `Path` for normal inputs, raising on invalid. Integration test that calls `ensure_parent_dir` and writes a file.
+
+
+## Medium Priority
+
+Rationale: Useful structural refactors that require more careful testing and staged rollout.
+
+### Stage 1: Extract parametrize name-resolution (medium risk)
+
+Task 4.1 - Move `_resolve_name_reference` and related helpers to `transformers/_resolvers.py`
+- Scope:
+  - Create a new module `transformers/_resolvers.py` containing `resolve_name_reference(name, statements, loop_index) -> (values, removable_index | None) | None`, mutation detection helpers, `_collect_constant_assignment_values`, and `_inline_constant_expression`.
+- Contract:
+  - Functions must be pure: accept `statements` (Sequence[cst.BaseStatement]) and `loop_index` and return deterministic results.
+  - Mutation detection returns True/False and provides clear documentation of the mutation heuristics (append/extend/assign/augassign and expression assignments).
+- Acceptance criteria:
+  - `parametrize_helper` should import the resolvers and call them with identical semantic behavior; tests should demonstrate parity on a representative fixture suite.
+- Implementation notes:
+  - Add property-based tests (pytest + hypothesis optional) to generate small statement sequences and assert invariants.
+- Tests:
+  - Unit tests that mirror previous `_resolve_name_reference` behavior, including: appended mutations, augmented assignments, multi-statement initializers, and non-resolvable cases.
+
+Task 4.2 - Make convert function explicitly accept options
+- Scope: Introduce a dataclass `ParametrizeOptions(parametrize_include_ids: bool, parametrize_add_annotations: bool)` and change `convert_subtest_loop_to_parametrize` signature to accept it rather than reading transformer attributes.
+- Acceptance criteria:
+  - Tests for parametrize behavior should construct `ParametrizeOptions` explicitly and validate decorated output remains unchanged.
+
+
+## Low Priority
+
+Rationale: Larger changes or nice-to-have features that are lower immediate ROI but improve long-term maintainability.
+
+### Stage 1: Incrementally split `assert_transformer.py` (medium risk)
+
+Task 5.1 - Identify logical boundaries and extract modules
+- Scope:
+  - Create `assert_ast_rewrites.py` (small pure functions operating on libcst nodes), `assert_with_rewrites.py` (helpers to transform With/Try bodies), and `assert_fallbacks.py` (string/regex-based fallbacks isolated and behind a flag).
+- Contract:
+  - Public APIs are pure functions with well-defined inputs and outputs.
+- Acceptance criteria:
+  - No change to observable behavior with default settings; isolated fallback module behind an `aggressive_fallbacks` flag in config.
+- Tests:
+  - Unit tests for each extracted module using representative cases.
+
+Task 5.2 - Add fallback corpus
+- Scope:
+  - Add `tests/fixtures/fallback_cases/` with pairs of input/output cases exercised by unit tests for `assert_fallbacks`.
+- Acceptance criteria:
+  - Tests fail if fallback changes output unexpectedly.
+
+
+## Cross-cutting concerns
+
+1. Testing strategy
+- For each functional extraction, add unit tests (happy path + 2–3 edge cases). Integration tests run the whole transform pipeline on small real-world-like files to confirm end-to-end parity.
+- Use `tmp_path` for filesystem tests; use `monkeypatch` to simulate permission errors or platform-specific behavior.
+
+2. CI / tooling
+- Add a CI job (or extend existing) that runs the test-suite with `SPLURGE_TRANSFORM_DEBUG=1` once for the PR pipeline to surface transformation exceptions early.
+- Add `ruff` and `mypy` jobs progressively; start with `--ignore-missing-imports` then tighten.
+
+3. Developer ergonomics
+- Add a short `docs/development/README.md` describing how to enable debug, run targeted tests, and add new fallback fixtures.
+
+
+## Acceptance criteria for the overall program
+- All unit tests pass locally and in CI after each staged PR.
+- Each extracted helper has unit tests with at least 80% coverage of its public API.
+- No behavioral regressions on the repository's transformation tests (run representative end-to-end transformations used by the current test-suite).
+- PRs are small, focused (< 300 lines change) where possible, and include changelog entries.
+
+
+## Rollout plan
+- Execute the High priority items as individual PRs, run full test-suite for each PR.
+- Merge Medium-High priority items once high priority PRs are green and stable.
+- For Medium priority extractions, produce stage gates and small PRs with follow-up tests.
+- Defer Low priority broader refactors to a dedicated branch and break into small PRs.
+
+
+---
+
+Notes
+- If you want, I can start implementing the first PR (`transformers/_caplog_helpers.py`) now and add unit tests, open a branch, and run the test-suite.
+
+Finalization notes (Stage 1 & 2)
+
+- Refactor summary: caplog-related detection and AST-construction logic was extracted from `assert_transformer.py` into `splurge_unittest_to_pytest.transformers._caplog_helpers`. This centralizes duplicate logic for alias output/records detection and for constructing `caplog.records[...]` and `.getMessage()` calls.
+- Compatibility shims: small wrapper functions and an exported dataclass were re-exported from `assert_transformer.py` to preserve the original module's public API (tests and other modules import underscore-prefixed helpers from `assert_transformer`). These shims are intentionally thin and delegate to the extracted helpers to keep reviewers' diffs small and preserve backwards compatibility.
+- Debug gate: a tiny `transformers/debug.py` helper (`get_transform_debug()` and `maybe_reraise()`) was added. When `SPLURGE_TRANSFORM_DEBUG` is truthy the code will re-raise transformation exceptions to aid debugging; by default behaviour is conservative and non-raising.
+- Tests added: unit tests were added for the new helpers and for the debug gate (`tests/unit/test_caplog_helpers_basic.py`, `tests/unit/test_debug_gate_basic.py`). The full test-suite was run and is green. These tests serve as the acceptance criteria for the refactor.
+
+Next steps: open a small PR with this change-set, include the new tests, and add a CI job to run the suite once with `SPLURGE_TRANSFORM_DEBUG=1` to surface exceptions during review.
+

--- a/docs/research/research-opportunities-for-improvements-2025-10-03.md
+++ b/docs/research/research-opportunities-for-improvements-2025-10-03.md
@@ -1,0 +1,277 @@
+## Research: Opportunities for simplification, SOLID design, and robustness
+
+Date: 2025-10-03
+
+This research note expands the initial review and captures detailed findings, concrete examples, edge cases, and prioritized engineering actions to simplify the codebase, align it with SOLID principles, and harden robustness. The review used the project's test suite as a safety net (945 tests passed locally) and examined high-complexity modules to identify targeted refactors.
+
+Executive summary
+-----------------
+- Test status: 945 tests passed (local run using pytest).
+- Coverage: ~86% overall — solid test baseline enabling safe, incremental refactors.
+- Primary modules reviewed in depth: `transformers/assert_transformer.py`, `transformers/parametrize_helper.py`, `helpers/path_utils.py`, `cli.py`, `circuit_breaker.py`.
+
+Why these files?
+- They are large or central orchestration points.
+- They contain complex logic mixing responsibilities (parsing, rewriting, string-level fallbacks, IO handling, CLI orchestration, or runtime safety logic).
+
+High-level opportunities
+------------------------
+1) Break large modules into single-responsibility parts
+
+Problems observed
+- Monolithic files combine discovery, analysis, and transformation concerns. Example: `assert_transformer.py` performs low-level libcst AST rewriting, higher-level with/alias rewrite orchestration, and fallback string regex replacements in the same module.
+
+Why it matters
+- Harder to reason about and test individual behaviors.
+- More likely to regress when patching unrelated code paths.
+
+Concrete approach
+- Split into smaller modules with small public APIs. Suggested splits for `assert_transformer.py`:
+	- `transformers/assert_ast_rewrites.py`: pure libcst node rewrites (input: node, output: new node or None).
+	- `transformers/assert_with_rewrites.py`: functions that transform With/Try/If bodies and perform lookahead rewrites.
+	- `transformers/assert_fallbacks.py`: conservative string-level (regex) fallbacks, explicitly opt-in and isolated.
+
+Testing
+- Unit test each module independently. For AST transforms, use small libcst code snippets and assert the produced CST matches expectations. For regex fallbacks, cover a matrix of representative inputs (captured from real-world tests or repository examples).
+
+2) Improve error handling observability without sacrificing safety
+
+Problems observed
+- Many helpers swallow exceptions (AttributeError, TypeError, IndexError, re.error) and return no-op results to remain safe.
+
+Why it matters
+- Silent failures make diagnosing root causes slow — especially with complex AST shapes.
+
+Concrete approach
+- Introduce a debug/CI mode (environment variable or config flag) that toggles re-raising of the first exception in transformation helpers.
+- Enhance `report_transformation_error()` to accept structured fields (component, operation, node snippet, full traceback) and write detailed debug logs when debug is enabled. Keep conservative behavior in production mode.
+
+Testing
+- Add tests that intentionally feed malformed AST shapes and ensure errors are logged; in debug mode they should raise.
+
+3) Centralize duplicated alias/caplog detection and construction logic
+
+Problems observed
+- Multiple places implement similar logic to detect `<alias>.output`, extract subscripts, and produce `caplog.records` or `.getMessage()` calls.
+
+Why it matters
+- Duplication increases maintenance burden and risk of inconsistent behavior.
+
+Concrete approach
+- Create `transformers/_caplog_helpers.py` exposing:
+	- `extract_alias_output_slices(expr) -> AliasOutputAccess | None`
+	- `build_caplog_records_expr(access) -> cst.BaseExpression`
+	- `build_get_message_call(access) -> cst.Call`
+- Replace duplicate code in `assert_transformer.py` and related modules with imports from this helpers module.
+
+Testing
+- Unit tests for each helper with subscripted, attribute, and nested forms.
+
+4) Make string-level fallbacks conservative and testable
+
+Problems observed
+- The regex fallback is comprehensive and attempts many tolerant rewrites. That breadth makes it brittle and hard to validate exhaustively.
+
+Why it matters
+- Regex rewrites can easily produce incorrect substitutions depending on formatting or unexpected input shapes.
+
+Concrete approach
+- Reduce the fallback to a minimal set of conservative rewrites (for example, rename `alias.exception` -> `alias.value` for known alias names). Keep aggressive rewrites behind a `--aggressive-fallbacks` flag.
+- Extract the fallback into its own module and add an explicit test corpus (real examples and edgecases).
+
+Testing
+- Create a tests/fixtures/fallback_cases directory containing example inputs and expected outputs; run assertions to ensure regressions are caught.
+
+5) Separate validation versus side effects in path utilities
+
+Problems observed
+- `helpers/path_utils.validate_target_path` both validates and creates parent directories (side-effect). It also uses `os.access` to check writability and enforces a hard-coded Windows 260 character path length limit.
+
+Why it matters
+- Validators that mutate the file system are surprising and make unit testing and dry-run flows harder. `os.access` may not reflect actual ACL-based permissions on Windows. The 260-char rule is legacy and not always applicable.
+
+Concrete approach
+- Split validation into pure checks and side-effect helpers:
+	- `validate_target_path(path, create_parent=False) -> Path` (pure validation)
+	- `ensure_parent_dir(path) -> None` (creates parent directories; called explicitly by writers)
+- Replace `os.access` check by attempting to open a temporary file in the parent directory (wrapped in try/except to catch PermissionError). Document the behavior and fall back to a warning if uncertain.
+- Replace strict path-length failure with a warning or config toggle; support `ALLOW_LONG_PATHS` configuration when caller enables it.
+
+Testing
+- Unit tests for validation logic, plus small integration test that uses temporary directories to validate behavior across Windows and POSIX semantics (CI may need matrixed runners to fully verify Windows behavior).
+
+6) Circuit breaker refinements
+
+Problems observed
+- Circuit breaker uses `signal.alarm()` for timeouts when available. The detection logic for signals is complex given cross-platform support. The module also maintains a global registry `_circuit_breakers` which can make tests order-dependent.
+
+Why it matters
+- Timeouts not supported on Windows should fail gracefully or use an alternative mechanism.
+- Global state complicates testing and increases surface for flakiness.
+
+Concrete approach
+- Make signal/timeout support explicit and documented: if `signal` based timeout is unavailable, either (A) document that the `timeout` option is ignored on the platform or (B) provide an explicit thread-based fallback that cancels the operation (careful — thread interrupts are harder in Python). Recommended: document and fallback to no-timeout rather than implement an ad-hoc thread interruption.
+- Add `reset_circuit_breaker(name)` and `reset_all_circuit_breakers()` test helpers. Optionally allow passing in a registry object to the `get_circuit_breaker()` factory for dependency injection in tests.
+
+Testing
+- Add unit tests that create a breaker, record failures, open the breaker, reset it, and verify stats. Also add tests ensuring that timeout paths on unsupported platforms don't raise unexpected exceptions.
+
+Detailed file-level notes and examples
+-----------------------------------
+
+Below are targeted observations from the inspected files with small code-level examples and recommended edits: 
+
+1. `transformers/assert_transformer.py` (high complexity)
+- Observed: functions such as `_rewrite_expression`, `_rewrite_comparison`, `_rewrite_equality_comparison`, and the caplog string fallbacks all live together. Several try/except blocks swallow errors and call `report_transformation_error(...)`.
+- Concrete example to extract:
+	- The pair `_extract_alias_output_slices` and `_build_caplog_records_expr/_build_get_message_call` appear in multiple places. Move them to `transformers/_caplog_helpers.py` and import them.
+
+Small PR idea
+- Create `transformers/_caplog_helpers.py` containing dataclass `AliasOutputAccess` and the 3 helpers. Update imports in `assert_transformer.py`.
+
+2. `transformers/parametrize_helper.py` (complex control flow and inference)
+- Observed: complicated name-resolution logic in `_resolve_name_reference` that scans prior statements for assignments and tries to detect mutation (append/extend). This is reasonable but brittle.
+- Concrete improvements:
+	- Isolate the name-resolution into `_resolvers.py` and add unit tests for mutated/unmutated cases.
+	- Provide more explicit docstrings describing the heuristic rules for mutation detection.
+
+3. `helpers/path_utils.py` (validation and IO mixing)
+- Observed issues and exact lines: the function `validate_target_path` currently creates `path.parent.mkdir(parents=True, exist_ok=True)` while also being named as a validator. This is a side-effect.
+
+Refactor steps
+- Remove the `mkdir()` call from `validate_target_path`. Create `ensure_parent_dir(path)` helper used by code paths that intentionally write files (for example the output job). This makes `validate_target_path` a pure function easier to test.
+
+4. `cli.py` (monolithic `migrate` function)
+- Observed: `migrate()` performs parsing of CLI options, loads YAML config, discovers files, sets up logging, attaches event handlers, and finally calls `main_module.migrate()`.
+
+Recommendations
+- Break into smaller helpers:
+	- `prepare_config_from_cli(...) -> MigrationConfig`
+	- `discover_files(...) -> list[str]`
+	- `setup_event_bus_and_logging(...) -> EventBus`
+	- `run_migration(valid_files, config, event_bus)`
+- Add unit tests for each helper, in particular test CLI flags normalization (negating flags like `--no-format` and their precedence).
+
+5. `circuit_breaker.py` (platform concerns and testability)
+- Observed: `_call_with_timeout` uses `signal.alarm()` when `HAS_SIGNAL` is true; however the `HAS_SIGNAL` detection logic depends on `TYPE_CHECKING` and `sys.platform` checks that complicate readability.
+
+Recommendation
+- Simplify detection:
+	- `HAS_SIGNAL = hasattr(signal, 'alarm')` (guard import with try/except) and document fallback.
+	- Add `reset_all()` test helper.
+
+Edge cases and likely pitfalls to test
+----------------------------------
+- AST transforms encountering unusual node shapes (e.g., AST created by other tools): ensure `TRANSFORM_DEBUG` re-raises to help diagnose.
+- Parametrize conversion referencing local mutable lists that are mutated later: ensure conversion rejects these (current heuristics try to detect appends but should be exercised with tests).
+- Windows path behaviors: `os.access` vs actual write attempts; use tmp files in tests to assert writable behavior where possible.
+- Regex fallbacks should have a minimal, well-documented set of transformations to avoid surprising replacements.
+
+Engineering contract (example) for transform helpers
+----------------------------------------------------
+- Inputs: single libcst node type (e.g., `cst.Call`) with a small list of expected shapes.
+- Output: `cst.CSTNode` replacement or `None` if no transformation.
+- Error modes: return `None` on unexpected shapes, but in `TRANSFORM_DEBUG` mode re-raise exceptions.
+
+Suggested immediate small PRs (concrete implementation roadmap)
+------------------------------------------------------------
+1. Extract caplog helpers (very low risk)
+	 - Files: add `transformers/_caplog_helpers.py`, update `assert_transformer.py` to import helpers, add unit tests for helper functions. Run full test suite.
+2. Make path validation pure (low risk)
+	 - Remove parent mkdir from `helpers/path_utils.validate_target_path` and add `helpers/path_utils.ensure_parent_dir` (callers that write files should call it explicitly). Update code paths that expected side-effects.
+3. CLI helperization (low risk)
+	 - Break `migrate` into smaller named helper functions and add unit tests for flag normalization.
+4. Circuit breaker test helpers and docs (low risk)
+	 - Add `reset_all_circuit_breakers()` and simplify signal detection.
+5. Split `assert_transformer.py` incrementally (medium risk)
+	 - Do this in small PRs, extract first `_caplog_helpers` then `with_rewrites`, keeping behavior stable.
+
+Developer tooling & CI suggestions
+--------------------------------
+- Add a `TRANSFORM_DEBUG` env var used by transform modules to enable strict error handling during CI runs.
+- Add a light `ruff` job and `mypy` run to CI (start with `--ignore-missing-imports` then tighten incrementally).
+- Add a `tests/fixtures/fallback_cases` corpus for testing regex fallback behavior.
+
+Requirements coverage mapping
+-----------------------------
+- Each recommendation was cross-checked against the current test run (945 passed). I prioritized low-risk edits that will be quick to validate with existing tests.
+
+Closing notes
+-------------
+This document contains engineering-minded recommendations focused on reducing per-file complexity, improving observability, and reducing duplication. I can implement the suggested low-risk PRs (starting with caplog helpers and path validation changes) and run the test-suite locally, or I can implement another item you prefer. Tell me which change you'd like first and I will create a small, test-covered PR.
+
+---
+Generated by an automated code review and paired analysis on 2025-10-03.
+
+---
+Generated by an automated code review and paired analysis on 2025-10-03.
+
+Key findings
+------------
+- Tests provide a safe baseline: the suite (945 tests) and coverage (~86%) allow small, incremental refactors with high confidence.
+- High-complexity hotspots: `transformers/assert_transformer.py` and `transformers/unittest_transformer.py` mix AST transforms, string fallbacks, and orchestration/state. These are prime candidates for targeted extraction and unit testing.
+- Parametrize heuristics are conservative but brittle: `transformers/parametrize_helper.py` contains careful resolution and mutation-detection logic that should be isolated and tested separately to avoid accidental regressions.
+- Duplication to remove first: caplog/caplog-alias handling appears in multiple transformers — extract helpers to reduce duplication and centralize tests.
+- Observability gap: many transformation helpers swallow exceptions. Add a `TRANSFORM_DEBUG` toggle for CI/dev to surface errors instead of silently continuing.
+
+Recommended next steps (short list)
+- Implement `transformers/_caplog_helpers.py` and update existing transformers to use it (low-risk, high-reward).
+- Make `helpers/path_utils.validate_target_path` a pure validator and add `ensure_parent_dir` for explicit side effects (low-risk).
+- Add `TRANSFORM_DEBUG` env var (or config flag) to re-raise transformation exceptions during CI runs for faster debugging (low-risk).
+- Extract name-resolution and mutation-detection from `parametrize_helper.py` into `transformers/_resolvers.py` (medium risk) and add focused unit tests.
+
+
+### Additional file-level analysis: `transformers/unittest_transformer.py`
+
+Summary
+- Role: Orchestrates CST transformations (fixture extraction, assertion rewrites, subTest handling, import cleanup).
+- Observations: The file is well-documented and conservative, but mixes orchestration with stateful fixture buffers, repeated defensive try/except blocks, and several legacy compatibility accessors that expose internal state (e.g., many property getters/setters for fixture collections).
+
+Issues and opportunities
+- Single responsibility: The class `UnittestToPytestCstTransformer` both coordinates multiple transformation phases and exposes a large mutable state API (fixture buffers, import flags, configuration knobs). Consider splitting orchestration from state (keep a small immutable config object and a separate mutable transformation context/state object).
+- Error handling: Many internal helpers swallow exceptions broadly (AttributeError, TypeError, ValueError) which is safe but makes debugging transformations hard. Introduce a `TRANSFORM_DEBUG` mode that re-raises the first exception for visibility during development/CI runs.
+- Fixture buffering: `FixtureCollectionState` holds many lists and per-class dicts. Its API currently exposes raw lists via properties and setters which can allow inconsistent mutation. Provide explicit methods for adding/clearing snippets and consider replacing lists with small dataclasses capturing the original statement span and source (to allow smarter deduplication and later diagnostics).
+- Replacement registry usage: The two-pass replacement approach using source positions is solid. However `record_replacement` silently ignores metadata failures; in `TRANSFORM_DEBUG` mode this should log or raise.
+- Caplog detection / request fixture injection: `_ensure_fixture_parameters` uses heuristics to add `request` and `caplog` params. Consider making the detection functions pure and separately testable and move them into a small helper module (for example `transformers/_fixture_param_detection.py`).
+
+Concrete small PRs
+- Extract `FixtureCollectionState` helpers: add methods `add_instance_setup`, `add_class_setup`, `get_module_fixtures` and keep internal structures private. This confines mutation points.
+- Add `TRANSFORM_DEBUG` env var support: when enabled, log full exception tracebacks and re-raise transformation exceptions in key places (record_replacement, _visit_with_metadata wrapper, and _apply_recorded_replacements).
+- Move caplog/request parameter detection to `transformers/_fixture_param_detection.py` and add unit tests that assert parameter injection when caplog/request usages are present.
+
+Testing notes
+- Add unit tests directly for `UnittestToPytestCstTransformer._transform_unittest_inheritance` and for `leave_Call` handling of a representative set of `self.assert*` shapes. These are already indirectly covered by the suite but explicit narrow tests reduce regressions.
+
+### Additional file-level analysis: `transformers/parametrize_helper.py`
+
+Summary
+- Role: Detects `for` loops with `with self.subTest(...)` and converts them into `pytest.mark.parametrize` decorators when safe.
+- Observations: The module is focused and reasonably well-isolated. It contains conservative heuristics for name-resolution and mutation detection. The logic is complex but appropriately cautious.
+
+Issues and opportunities
+- Name-resolution complexity: `_resolve_name_reference` walks backwards to find prior assignments and tries to detect mutation (append/extend etc.). This is correct but brittle and hard to extend.
+- Implicit assumptions: The code assumes that assignment nodes are simple and that mutation operations take familiar forms. Unusual mutation patterns (list comprehensions, calls to helper functions that mutate an accumulator) will be missed.
+- Coupling to transformer flags: The function reads `transformer.parametrize_include_ids` and `transformer.parametrize_add_annotations`. Consider passing a small options dataclass to the conversion helper so this module's API is explicit and testable in isolation.
+
+Concrete small PRs
+- Move name-resolution and mutation-detection to `transformers/_resolvers.py` as pure functions with a clear contract:
+	- inputs: (name, statements, loop_index)
+	- outputs: (tuple[expressions], removable_index | None)
+	- tests: mutated vs unmutated assignments, augmented assignment cases, in-place mutation calls, and compound statements.
+- Make `convert_subtest_loop_to_parametrize` accept an explicit `ParametrizeOptions` dataclass instead of reading attributes from the transformer. This makes unit testing easier and decouples it from the transformer's mutable state.
+- Add more tests for `_infer_param_annotations` to show behavior when rows mix compatible types vs incompatible types.
+
+Testing notes
+- Add parametrize helper tests focusing on edgecases:
+	- enumerate() wrapping mutable lists
+	- mapping .items / .keys / .values conversion
+	- range() with more than 20 elements (should reject)
+	- local constants in rows and proper inlining behavior
+
+Mapping to prior recommendations
+- These file-level changes dovetail with the earlier suggestions: extracting helpers (caplog, resolvers), reducing mutation surface, and adding a TRANSFORM_DEBUG mode that raises in development/CI for faster diagnosis.
+
+Next steps (this todo will be marked completed after tests run)
+- Append this analysis to the repository (done).
+- Run the test suite to ensure changes didn't break anything (will run next).
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ dev = [
     "ruff>=0.1.0",
     "pre-commit>=3.0.0",
     "pytest-xdist>=3.0.0",
-    "black>=23.0.0",
-    "isort>=5.12.0",
+    # Note: `black` and `isort` are intentionally kept as runtime dependencies above
+    # because the library uses them as part of its packaging/runtime behavior.
 ]
 
 [project.scripts]

--- a/splurge_unittest_to_pytest/cli.py
+++ b/splurge_unittest_to_pytest/cli.py
@@ -991,7 +991,9 @@ def version() -> None:
 
 
 @app.command("init-config")
-def init_config(output_file: str = typer.Argument("splurge-unittest-to-pytest.yaml", help="Output configuration file")) -> None:
+def init_config(
+    output_file: str = typer.Argument("splurge-unittest-to-pytest.yaml", help="Output configuration file"),
+) -> None:
     """Initialize a configuration file with default settings.
 
     This command creates a configuration file with all available options

--- a/splurge_unittest_to_pytest/migration_orchestrator.py
+++ b/splurge_unittest_to_pytest/migration_orchestrator.py
@@ -89,9 +89,13 @@ class MigrationOrchestrator:
             src_path = validated_source
             dest_dir = Path(config.target_root)
 
-            # Validate and prepare target directory
+            # Validate target directory (pure validation) and ensure parent dir exists
             try:
-                validated_target_dir = validate_target_path(dest_dir, create_parent=True)
+                validated_target_dir = validate_target_path(dest_dir)
+                # Perform the side-effect of creating parent directories
+                from .helpers.path_utils import ensure_parent_dir
+
+                ensure_parent_dir(validated_target_dir)
             except PathValidationError as e:
                 return Result.failure(e)
 

--- a/splurge_unittest_to_pytest/transformers/__init__.py
+++ b/splurge_unittest_to_pytest/transformers/__init__.py
@@ -14,3 +14,13 @@ from .unittest_transformer import (
 __all__ = [
     "UnittestToPytestCstTransformer",
 ]
+
+# Re-export the new assert split modules for convenient imports while we
+# perform the staged refactor.
+from . import (
+    assert_ast_rewrites,
+    assert_fallbacks,
+    assert_with_rewrites,
+)  # noqa: F401
+
+__all__ += ["assert_ast_rewrites", "assert_with_rewrites", "assert_fallbacks"]

--- a/splurge_unittest_to_pytest/transformers/_caplog_helpers.py
+++ b/splurge_unittest_to_pytest/transformers/_caplog_helpers.py
@@ -61,4 +61,6 @@ def build_caplog_records_expr(access: AliasOutputAccess) -> cst.BaseExpression:
 
 def build_get_message_call(access: AliasOutputAccess) -> cst.Call:
     """Construct `caplog.records[...].getMessage()` call for the provided access."""
-    return cst.Call(func=cst.Attribute(value=build_caplog_records_expr(access), attr=cst.Name(value="getMessage")), args=[])
+    return cst.Call(
+        func=cst.Attribute(value=build_caplog_records_expr(access), attr=cst.Name(value="getMessage")), args=[]
+    )

--- a/splurge_unittest_to_pytest/transformers/_caplog_helpers.py
+++ b/splurge_unittest_to_pytest/transformers/_caplog_helpers.py
@@ -1,0 +1,64 @@
+"""Caplog helper utilities extracted from assert_transformer.
+
+Provide small pure helpers to detect <alias>.output/records access and
+to construct libcst fragments for `caplog.records` and `.getMessage()`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import cast
+
+import libcst as cst
+
+
+@dataclass(frozen=True)
+class AliasOutputAccess:
+    alias_name: str
+    slices: tuple[cst.SubscriptElement, ...]
+
+
+def extract_alias_output_slices(expr: cst.BaseExpression) -> AliasOutputAccess | None:
+    """Return alias/output access when expr is `<alias>.output...` or `<alias>.records...`.
+
+    Returns None for unrecognized shapes.
+    """
+    slices: list[cst.SubscriptElement] = []
+    current: cst.BaseExpression = expr
+
+    while isinstance(current, cst.Subscript):
+        # current.slice may be a Sequence[SubscriptElement] or a single SubscriptElement.
+        slice_val = current.slice
+        # If it's a sequence, insert its elements preserving order; otherwise insert the single element.
+        if isinstance(slice_val, list | tuple):
+            # Prepend all elements preserving order
+            slices[0:0] = list(slice_val)
+        else:
+            # mypy cannot always narrow `slice_val` to a single SubscriptElement, so cast it here.
+            slices.insert(0, cast(cst.SubscriptElement, slice_val))
+        # `current.value` is the expression being subscripted (the next node up)
+        current = current.value
+
+    if (
+        isinstance(current, cst.Attribute)
+        and isinstance(current.value, cst.Name)
+        and isinstance(current.attr, cst.Name)
+        and current.attr.value in {"output", "records"}
+    ):
+        return AliasOutputAccess(alias_name=current.value.value, slices=tuple(slices))
+
+    return None
+
+
+def build_caplog_records_expr(access: AliasOutputAccess) -> cst.BaseExpression:
+    """Construct `caplog.records` expression and apply subscripts from access.slices."""
+    base: cst.BaseExpression = cst.Attribute(value=cst.Name(value="caplog"), attr=cst.Name(value="records"))
+    for slice_item in access.slices:
+        # cst.Subscript expects a sequence of SubscriptElement for the `slice` parameter.
+        base = cst.Subscript(value=base, slice=(slice_item,))
+    return base
+
+
+def build_get_message_call(access: AliasOutputAccess) -> cst.Call:
+    """Construct `caplog.records[...].getMessage()` call for the provided access."""
+    return cst.Call(func=cst.Attribute(value=build_caplog_records_expr(access), attr=cst.Name(value="getMessage")), args=[])

--- a/splurge_unittest_to_pytest/transformers/_resolvers.py
+++ b/splurge_unittest_to_pytest/transformers/_resolvers.py
@@ -3,6 +3,7 @@
 These helpers are pure functions operating on sequences of libcst statements
 and are safe to unit test in isolation.
 """
+
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence

--- a/splurge_unittest_to_pytest/transformers/_resolvers.py
+++ b/splurge_unittest_to_pytest/transformers/_resolvers.py
@@ -1,0 +1,265 @@
+"""Name-resolution and literal-extraction helpers extracted from parametrize_helper.
+
+These helpers are pure functions operating on sequences of libcst statements
+and are safe to unit test in isolation.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import cast
+
+import libcst as cst
+
+from ..exceptions import ParametrizeConversionError
+
+
+class _RemovalCandidate:
+    def __init__(self, index: int, name: str | None) -> None:
+        self.index = index
+        self.name = name
+
+
+def _extract_literal_elements(node: cst.BaseExpression) -> tuple[cst.BaseExpression, ...] | None:
+    if isinstance(node, cst.List | cst.Tuple):
+        elements: list[cst.BaseExpression] = []
+        for element in node.elements:
+            if not isinstance(element, cst.Element):
+                return None
+            elements.append(element.value)
+        return tuple(elements)
+    return None
+
+
+def _extract_dict_pairs(node: cst.BaseExpression) -> tuple[tuple[cst.BaseExpression, cst.BaseExpression], ...] | None:
+    if not isinstance(node, cst.Dict):
+        return None
+
+    pairs: list[tuple[cst.BaseExpression, cst.BaseExpression]] = []
+    for element in node.elements:
+        if not isinstance(element, cst.DictElement):
+            return None
+        pairs.append((element.key, element.value))
+
+    return tuple(pairs)
+
+
+def _resolve_name_reference(
+    name: str,
+    statements: Sequence[cst.BaseStatement],
+    loop_index: int,
+) -> tuple[tuple[cst.BaseExpression, ...], int | None] | None:
+    for idx in range(loop_index - 1, -1, -1):
+        stmt = statements[idx]
+        if isinstance(stmt, cst.SimpleStatementLine):
+            for small_stmt in stmt.body:
+                if isinstance(small_stmt, cst.Assign):
+                    if len(small_stmt.targets) != 1:
+                        continue
+                    target = small_stmt.targets[0].target
+                    if isinstance(target, cst.Name) and target.value == name:
+                        elements = _extract_literal_elements(small_stmt.value)
+                        if elements is not None:
+                            mutated = False
+                            for midx in range(idx + 1, loop_index):
+                                mid_stmt = statements[midx]
+                                if isinstance(mid_stmt, cst.SimpleStatementLine):
+                                    for mid_small in mid_stmt.body:
+                                        if isinstance(mid_small, cst.Expr) and isinstance(mid_small.value, cst.Call):
+                                            func = mid_small.value.func
+                                            if isinstance(func, cst.Attribute) and isinstance(func.value, cst.Name):
+                                                if func.value.value == name and isinstance(func.attr, cst.Name):
+                                                    if func.attr.value in {
+                                                        "append",
+                                                        "extend",
+                                                        "insert",
+                                                        "pop",
+                                                        "clear",
+                                                        "remove",
+                                                        "appendleft",
+                                                    }:
+                                                        mutated = True
+                                                        break
+                                        if isinstance(mid_small, cst.Assign):
+                                            for t in mid_small.targets:
+                                                if isinstance(t.target, cst.Name) and t.target.value == name:
+                                                    mutated = True
+                                                    break
+                                    if mutated:
+                                        break
+                                if isinstance(mid_stmt, cst.AugAssign):
+                                    target = mid_stmt.target
+                                    if isinstance(target, cst.Name) and target.value == name:
+                                        mutated = True
+                                        break
+
+                            if mutated:
+                                return None
+
+                            removable_index: int | None = idx if len(stmt.body) == 1 else None
+                            return elements, removable_index
+    return None
+
+
+def _resolve_sequence_argument(
+    expr: cst.BaseExpression,
+    statements: Sequence[cst.BaseStatement],
+    loop_index: int,
+) -> tuple[tuple[cst.BaseExpression, ...], tuple[_RemovalCandidate, ...]]:
+    literal_values = _extract_literal_elements(expr)
+    if literal_values is not None:
+        return literal_values, ()
+
+    if isinstance(expr, cst.Name):
+        resolution = _resolve_name_reference(expr.value, statements, loop_index)
+        if resolution is None:
+            raise ParametrizeConversionError
+        values, removable_index = resolution
+        if removable_index is None:
+            return values, ()
+        return values, (_RemovalCandidate(index=removable_index, name=expr.value),)
+
+    raise ParametrizeConversionError
+
+
+def _resolve_mapping_argument(
+    expr: cst.BaseExpression,
+    statements: Sequence[cst.BaseStatement],
+    loop_index: int,
+) -> tuple[tuple[tuple[cst.BaseExpression, cst.BaseExpression], ...], tuple[_RemovalCandidate, ...]]:
+    direct_pairs = _extract_dict_pairs(expr)
+    if direct_pairs is not None:
+        return direct_pairs, ()
+
+    if not isinstance(expr, cst.Name):
+        raise ParametrizeConversionError
+
+    name = expr.value
+    for idx in range(loop_index - 1, -1, -1):
+        stmt = statements[idx]
+        if not isinstance(stmt, cst.SimpleStatementLine):
+            continue
+        for small_stmt in stmt.body:
+            if not isinstance(small_stmt, cst.Assign):
+                continue
+            if len(small_stmt.targets) != 1:
+                continue
+            target = small_stmt.targets[0].target
+            if not isinstance(target, cst.Name) or target.value != name:
+                continue
+            pairs = _extract_dict_pairs(small_stmt.value)
+            if pairs is None:
+                raise ParametrizeConversionError
+            removal: tuple[_RemovalCandidate, ...]
+            if len(stmt.body) == 1:
+                removal = (_RemovalCandidate(index=idx, name=name),)
+            else:
+                removal = ()
+            return pairs, removal
+
+    raise ParametrizeConversionError
+
+
+def _collect_constant_assignment_values(
+    statements: Sequence[cst.BaseStatement],
+    loop_index: int,
+) -> dict[str, cst.BaseExpression]:
+    constants: dict[str, cst.BaseExpression] = {}
+
+    for index in range(loop_index):
+        stmt = statements[index]
+        if not isinstance(stmt, cst.SimpleStatementLine):
+            continue
+        for small_stmt in stmt.body:
+            if isinstance(small_stmt, cst.Assign):
+                if len(small_stmt.targets) != 1:
+                    continue
+                target = small_stmt.targets[0].target
+                if not isinstance(target, cst.Name):
+                    continue
+                value_expr = small_stmt.value
+                if _expression_is_constant(value_expr):
+                    constants[target.value] = value_expr
+            elif isinstance(small_stmt, cst.AnnAssign):
+                target = small_stmt.target
+                if not isinstance(target, cst.Name):
+                    continue
+
+                value_node = small_stmt.value
+                if value_node is None:
+                    continue
+                value_expr = value_node
+                if _expression_is_constant(value_expr):
+                    constants[target.value] = value_expr
+
+    return constants
+
+
+def _inline_constant_expression(
+    expression: cst.BaseExpression,
+    constants: Mapping[str, cst.BaseExpression],
+) -> cst.BaseExpression:
+    class _ConstantInliner(cst.CSTTransformer):
+        def __init__(self, mapping: Mapping[str, cst.BaseExpression]) -> None:
+            self.mapping = mapping
+
+        def leave_Name(
+            self,
+            original_node: cst.Name,
+            updated_node: cst.Name,
+        ) -> cst.BaseExpression:  # noqa: D401 - libcst signature
+            replacement = self.mapping.get(original_node.value)
+            if replacement is None:
+                return updated_node
+            return replacement.deep_clone()
+
+    transformer = _ConstantInliner(constants)
+    updated = expression.visit(transformer)
+    return cast(cst.BaseExpression, updated)
+
+
+def _expression_is_constant(expression: cst.CSTNode) -> bool:
+    if isinstance(expression, cst.Integer | cst.Float | cst.SimpleString):
+        return True
+
+    if isinstance(expression, cst.Name):
+        return expression.value in {"True", "False", "None"}
+
+    if isinstance(expression, cst.UnaryOperation):
+        return _expression_is_constant(expression.expression)
+
+    if isinstance(expression, cst.List | cst.Tuple | cst.Set):
+        return all(
+            isinstance(element, cst.Element) and _expression_is_constant(element.value)
+            for element in expression.elements
+        )
+
+    if isinstance(expression, cst.Dict):
+        return all(
+            isinstance(element, cst.DictElement)
+            and element.key is not None
+            and _expression_is_constant(element.key)
+            and _expression_is_constant(element.value)
+            for element in expression.elements
+        )
+
+    if isinstance(expression, cst.BinaryOperation):
+        return _expression_is_constant(expression.left) and _expression_is_constant(expression.right)
+
+    if isinstance(expression, cst.Attribute):
+        return _expression_is_constant(expression.value)
+
+    return False
+
+
+def _collect_expression_names(expression: cst.CSTNode) -> set[str]:
+    ignored = {"True", "False", "None"}
+    collected: set[str] = set()
+
+    class _Collector(cst.CSTVisitor):
+        def visit_Name(self, node: cst.Name) -> bool:  # noqa: N802 - libcst naming
+            collected.add(node.value)
+            return True
+
+    expression.visit(_Collector())
+
+    return collected.difference(ignored)

--- a/splurge_unittest_to_pytest/transformers/assert_ast_rewrites.py
+++ b/splurge_unittest_to_pytest/transformers/assert_ast_rewrites.py
@@ -1,0 +1,30 @@
+"""AST-shaped assertion rewrite helpers (stage-1 shim).
+
+This module provides a small, stable surface for pure AST rewrite
+helpers extracted from ``assert_transformer``. Initially these are
+thin shims that delegate to the original module so the behaviour is
+unchanged while we incrementally move implementations.
+
+Do not add new behaviour here; prefer to move code from
+``assert_transformer.py`` into this module in follow-up commits.
+"""
+
+from typing import Any
+
+import libcst as cst
+
+# Import the original implementations as shims to minimize the diff.
+from . import assert_transformer as _orig
+
+
+def parenthesized_expression(expr: cst.BaseExpression) -> Any:
+    """Delegate to the original parenthesized_expression helper."""
+
+    return _orig.parenthesized_expression(expr)
+
+
+# Expose the dataclass type for callers that use isinstance checks.
+ParenthesizedExpression: type[Any] = _orig.ParenthesizedExpression
+
+
+__all__ = ["parenthesized_expression", "ParenthesizedExpression"]

--- a/splurge_unittest_to_pytest/transformers/assert_ast_rewrites.py
+++ b/splurge_unittest_to_pytest/transformers/assert_ast_rewrites.py
@@ -1,30 +1,385 @@
-"""AST-shaped assertion rewrite helpers (stage-1 shim).
+"""AST-shaped assertion rewrite helpers.
 
-This module provides a small, stable surface for pure AST rewrite
-helpers extracted from ``assert_transformer``. Initially these are
-thin shims that delegate to the original module so the behaviour is
-unchanged while we incrementally move implementations.
-
-Do not add new behaviour here; prefer to move code from
-``assert_transformer.py`` into this module in follow-up commits.
+This module contains the pure, structural transformations for
+unittest-style assertions that do not depend on caplog or context
+manager rewrites. These helpers operate on libcst nodes and are
+safe to test in isolation.
 """
 
+from dataclasses import dataclass
 from typing import Any
 
 import libcst as cst
 
-# Import the original implementations as shims to minimize the diff.
-from . import assert_transformer as _orig
+__all__ = [
+    "ParenthesizedExpression",
+    "parenthesized_expression",
+    "transform_assert_equal",
+    "transform_assert_not_almost_equal",
+    "transform_assert_true",
+    "transform_assert_false",
+    "transform_assert_is",
+    "transform_assert_not_equal",
+    "transform_assert_is_not",
+    "transform_assert_is_none",
+    "transform_assert_is_not_none",
+    "transform_assert_not_in",
+    "transform_assert_isinstance",
+    "transform_assert_not_isinstance",
+    "transform_assert_count_equal",
+    "transform_assert_multiline_equal",
+    "transform_assert_regex",
+    "transform_assert_not_regex",
+    "transform_assert_in",
+    "transform_assert_dict_equal",
+    "transform_assert_list_equal",
+    "transform_assert_set_equal",
+    "transform_assert_tuple_equal",
+    "transform_assert_greater",
+    "transform_assert_greater_equal",
+    "transform_assert_less",
+    "transform_assert_less_equal",
+    "transform_assert_almost_equal",
+    "transform_assert_almost_equals",
+    "transform_assert_not_almost_equals",
+]
 
 
-def parenthesized_expression(expr: cst.BaseExpression) -> Any:
-    """Delegate to the original parenthesized_expression helper."""
+@dataclass(frozen=True)
+class ParenthesizedExpression:
+    """Capture parentheses metadata attached to an expression node."""
 
-    return _orig.parenthesized_expression(expr)
+    has_parentheses: bool
+    lpar: tuple[cst.LeftParen, ...]
+    rpar: tuple[cst.RightParen, ...]
+
+    def strip(self, expr: cst.BaseExpression) -> cst.BaseExpression:
+        if not self.has_parentheses or not hasattr(expr, "with_changes"):
+            return expr
+
+        updates: dict[str, tuple[object, ...]] = {}
+        if hasattr(expr, "lpar"):
+            updates["lpar"] = ()
+        if hasattr(expr, "rpar"):
+            updates["rpar"] = ()
+
+        return expr.with_changes(**updates) if updates else expr
+
+    def restore(self, expr: cst.BaseExpression) -> cst.BaseExpression:
+        if not self.has_parentheses or not hasattr(expr, "with_changes"):
+            return expr
+
+        updates: dict[str, tuple[object, ...]] = {}
+        if hasattr(expr, "lpar"):
+            updates["lpar"] = self.lpar
+        if hasattr(expr, "rpar"):
+            updates["rpar"] = self.rpar
+
+        return expr.with_changes(**updates) if updates else expr
 
 
-# Expose the dataclass type for callers that use isinstance checks.
-ParenthesizedExpression: type[Any] = _orig.ParenthesizedExpression
+def parenthesized_expression(expr: cst.BaseExpression) -> ParenthesizedExpression:
+    lpar = tuple(getattr(expr, "lpar", ()))
+    rpar = tuple(getattr(expr, "rpar", ()))
+    return ParenthesizedExpression(has_parentheses=bool(lpar or rpar), lpar=lpar, rpar=rpar)
 
 
-__all__ = ["parenthesized_expression", "ParenthesizedExpression"]
+def transform_assert_equal(node: cst.Call) -> cst.CSTNode:
+    if len(node.args) >= 2:
+        comp = cst.Comparison(
+            left=node.args[0].value,
+            comparisons=[cst.ComparisonTarget(operator=cst.Equal(), comparator=node.args[1].value)],
+        )
+        return cst.Assert(test=comp)
+    return node
+
+
+def transform_assert_not_almost_equal(node: cst.Call, config: Any | None = None) -> cst.CSTNode:
+    if len(node.args) >= 2:
+        left = node.args[0].value
+        right = node.args[1].value
+        places = None
+        for arg in node.args:
+            if arg.keyword and isinstance(arg.keyword, cst.Name) and arg.keyword.value == "places":
+                places = arg.value
+                break
+        if places is None:
+            places_value = getattr(config, "assert_almost_equal_places", 7) if config else 7
+            places = cst.Integer(value=str(places_value))
+        diff = cst.BinaryOperation(left=left, operator=cst.Subtract(), right=right)
+        round_call = cst.Call(func=cst.Name(value="round"), args=[cst.Arg(value=diff), cst.Arg(value=places)])
+        comp = cst.Comparison(
+            left=round_call,
+            comparisons=[cst.ComparisonTarget(operator=cst.Equal(), comparator=cst.Integer(value="0"))],
+        )
+        return cst.Assert(test=cst.UnaryOperation(operator=cst.Not(), expression=comp))
+    return node
+
+
+def transform_assert_true(node: cst.Call) -> cst.CSTNode:
+    if len(node.args) >= 1:
+        return cst.Assert(test=node.args[0].value)
+    return node
+
+
+def transform_assert_false(node: cst.Call) -> cst.CSTNode:
+    if len(node.args) >= 1:
+        return cst.Assert(test=cst.UnaryOperation(operator=cst.Not(), expression=node.args[0].value))
+    return node
+
+
+def transform_assert_is(node: cst.Call) -> cst.CSTNode:
+    if len(node.args) >= 2:
+        comp = cst.Comparison(
+            left=node.args[0].value,
+            comparisons=[cst.ComparisonTarget(operator=cst.Is(), comparator=node.args[1].value)],
+        )
+        return cst.Assert(test=comp)
+    return node
+
+
+def transform_assert_not_equal(node: cst.Call) -> cst.CSTNode:
+    if len(node.args) >= 2:
+        comp = cst.Comparison(
+            left=node.args[0].value,
+            comparisons=[cst.ComparisonTarget(operator=cst.NotEqual(), comparator=node.args[1].value)],
+        )
+        return cst.Assert(test=comp)
+    return node
+
+
+def transform_assert_is_not(node: cst.Call) -> cst.CSTNode:
+    if len(node.args) >= 2:
+        comp = cst.Comparison(
+            left=node.args[0].value,
+            comparisons=[cst.ComparisonTarget(operator=cst.IsNot(), comparator=node.args[1].value)],
+        )
+        return cst.Assert(test=comp)
+    return node
+
+
+def transform_assert_is_none(node: cst.Call) -> cst.CSTNode:
+    if len(node.args) >= 1:
+        comp = cst.Comparison(
+            left=node.args[0].value,
+            comparisons=[cst.ComparisonTarget(operator=cst.Is(), comparator=cst.Name(value="None"))],
+        )
+        return cst.Assert(test=comp)
+    return node
+
+
+def transform_assert_is_not_none(node: cst.Call) -> cst.CSTNode:
+    if len(node.args) >= 1:
+        comp = cst.Comparison(
+            left=node.args[0].value,
+            comparisons=[cst.ComparisonTarget(operator=cst.IsNot(), comparator=cst.Name(value="None"))],
+        )
+        return cst.Assert(test=comp)
+    return node
+
+
+def transform_assert_not_in(node: cst.Call) -> cst.CSTNode:
+    if len(node.args) >= 2:
+        comp = cst.Comparison(
+            left=node.args[0].value,
+            comparisons=[cst.ComparisonTarget(operator=cst.NotIn(), comparator=node.args[1].value)],
+        )
+        return cst.Assert(test=comp)
+    return node
+
+
+def transform_assert_isinstance(node: cst.Call) -> cst.CSTNode:
+    if len(node.args) >= 2:
+        isinstance_call = cst.Call(
+            func=cst.Name(value="isinstance"),
+            args=[cst.Arg(value=node.args[0].value), cst.Arg(value=node.args[1].value)],
+        )
+        return cst.Assert(test=isinstance_call)
+    return node
+
+
+def transform_assert_not_isinstance(node: cst.Call) -> cst.CSTNode:
+    if len(node.args) >= 2:
+        isinstance_call = cst.Call(
+            func=cst.Name(value="isinstance"),
+            args=[cst.Arg(value=node.args[0].value), cst.Arg(value=node.args[1].value)],
+        )
+        return cst.Assert(test=cst.UnaryOperation(operator=cst.Not(), expression=isinstance_call))
+    return node
+
+
+def transform_assert_count_equal(node: cst.Call) -> cst.CSTNode:
+    if len(node.args) >= 2:
+        left = cst.Call(func=cst.Name(value="sorted"), args=[cst.Arg(value=node.args[0].value)])
+        right = cst.Call(func=cst.Name(value="sorted"), args=[cst.Arg(value=node.args[1].value)])
+        comp = cst.Comparison(left=left, comparisons=[cst.ComparisonTarget(operator=cst.Equal(), comparator=right)])
+        return cst.Assert(test=comp)
+    return node
+
+
+def transform_assert_multiline_equal(node: cst.Call) -> cst.CSTNode:
+    if len(node.args) >= 2:
+        comp = cst.Comparison(
+            left=node.args[0].value,
+            comparisons=[cst.ComparisonTarget(operator=cst.Equal(), comparator=node.args[1].value)],
+        )
+        return cst.Assert(test=comp)
+    return node
+
+
+def transform_assert_regex(
+    node: cst.Call, re_alias: str | None = None, re_search_name: str | None = None
+) -> cst.CSTNode:
+    if len(node.args) >= 2:
+        if re_search_name:
+            func: cst.BaseExpression = cst.Name(value=re_search_name)
+        else:
+            re_name = re_alias or "re"
+            func = cst.Attribute(value=cst.Name(value=re_name), attr=cst.Name(value="search"))
+
+        call = cst.Call(func=func, args=[cst.Arg(value=node.args[1].value), cst.Arg(value=node.args[0].value)])
+        return cst.Assert(test=call)
+    return node
+
+
+def transform_assert_not_regex(
+    node: cst.Call, re_alias: str | None = None, re_search_name: str | None = None
+) -> cst.CSTNode:
+    if len(node.args) >= 2:
+        if re_search_name:
+            func: cst.BaseExpression = cst.Name(value=re_search_name)
+        else:
+            re_name = re_alias or "re"
+            func = cst.Attribute(value=cst.Name(value=re_name), attr=cst.Name(value="search"))
+
+        call = cst.Call(func=func, args=[cst.Arg(value=node.args[1].value), cst.Arg(value=node.args[0].value)])
+        return cst.Assert(test=cst.UnaryOperation(operator=cst.Not(), expression=call))
+    return node
+
+
+def transform_assert_in(node: cst.Call) -> cst.CSTNode:
+    if len(node.args) >= 2:
+        comp = cst.Comparison(
+            left=node.args[0].value,
+            comparisons=[cst.ComparisonTarget(operator=cst.In(), comparator=node.args[1].value)],
+        )
+        return cst.Assert(test=comp)
+    return node
+
+
+def transform_assert_dict_equal(node: cst.Call) -> cst.CSTNode:
+    if len(node.args) >= 2:
+        comp = cst.Comparison(
+            left=node.args[0].value,
+            comparisons=[cst.ComparisonTarget(operator=cst.Equal(), comparator=node.args[1].value)],
+        )
+        return cst.Assert(test=comp)
+    return node
+
+
+def transform_assert_list_equal(node: cst.Call) -> cst.CSTNode:
+    if len(node.args) >= 2:
+        comp = cst.Comparison(
+            left=node.args[0].value,
+            comparisons=[cst.ComparisonTarget(operator=cst.Equal(), comparator=node.args[1].value)],
+        )
+        return cst.Assert(test=comp)
+    return node
+
+
+def transform_assert_set_equal(node: cst.Call) -> cst.CSTNode:
+    if len(node.args) >= 2:
+        comp = cst.Comparison(
+            left=node.args[0].value,
+            comparisons=[cst.ComparisonTarget(operator=cst.Equal(), comparator=node.args[1].value)],
+        )
+        return cst.Assert(test=comp)
+    return node
+
+
+def transform_assert_tuple_equal(node: cst.Call) -> cst.CSTNode:
+    if len(node.args) >= 2:
+        comp = cst.Comparison(
+            left=node.args[0].value,
+            comparisons=[cst.ComparisonTarget(operator=cst.Equal(), comparator=node.args[1].value)],
+        )
+        return cst.Assert(test=comp)
+    return node
+
+
+def transform_assert_greater(node: cst.Call) -> cst.CSTNode:
+    if len(node.args) >= 2:
+        comp = cst.Comparison(
+            left=node.args[0].value,
+            comparisons=[cst.ComparisonTarget(operator=cst.GreaterThan(), comparator=node.args[1].value)],
+        )
+        return cst.Assert(test=comp)
+    return node
+
+
+def transform_assert_greater_equal(node: cst.Call) -> cst.CSTNode:
+    if len(node.args) >= 2:
+        comp = cst.Comparison(
+            left=node.args[0].value,
+            comparisons=[cst.ComparisonTarget(operator=cst.GreaterThanEqual(), comparator=node.args[1].value)],
+        )
+        return cst.Assert(test=comp)
+    return node
+
+
+def transform_assert_less(node: cst.Call) -> cst.CSTNode:
+    if len(node.args) >= 2:
+        comp = cst.Comparison(
+            left=node.args[0].value,
+            comparisons=[cst.ComparisonTarget(operator=cst.LessThan(), comparator=node.args[1].value)],
+        )
+        return cst.Assert(test=comp)
+    return node
+
+
+def transform_assert_less_equal(node: cst.Call) -> cst.CSTNode:
+    if len(node.args) >= 2:
+        comp = cst.Comparison(
+            left=node.args[0].value,
+            comparisons=[cst.ComparisonTarget(operator=cst.LessThanEqual(), comparator=node.args[1].value)],
+        )
+        return cst.Assert(test=comp)
+    return node
+
+
+def transform_assert_almost_equal(node: cst.Call, config: Any | None = None) -> cst.CSTNode:
+    if len(node.args) >= 2:
+        left = node.args[0].value
+        right = node.args[1].value
+        places = None
+        for arg in node.args:
+            if arg.keyword and isinstance(arg.keyword, cst.Name) and arg.keyword.value == "places":
+                places = arg.value
+                break
+        if places is None:
+            approx_call = cst.Call(
+                func=cst.Attribute(value=cst.Name(value="pytest"), attr=cst.Name(value="approx")),
+                args=[cst.Arg(value=right)],
+            )
+            comp = cst.Comparison(
+                left=left, comparisons=[cst.ComparisonTarget(operator=cst.Equal(), comparator=approx_call)]
+            )
+            return cst.Assert(test=comp)
+        else:
+            diff = cst.BinaryOperation(left=left, operator=cst.Subtract(), right=right)
+            round_call = cst.Call(func=cst.Name(value="round"), args=[cst.Arg(value=diff), cst.Arg(value=places)])
+            comp = cst.Comparison(
+                left=round_call,
+                comparisons=[cst.ComparisonTarget(operator=cst.Equal(), comparator=cst.Integer(value="0"))],
+            )
+            return cst.Assert(test=comp)
+    return node
+
+
+def transform_assert_almost_equals(node: cst.Call) -> cst.CSTNode:
+    return transform_assert_almost_equal(node)
+
+
+def transform_assert_not_almost_equals(node: cst.Call) -> cst.CSTNode:
+    # delegate to not_almost logic if present
+    return transform_assert_not_almost_equal(node)

--- a/splurge_unittest_to_pytest/transformers/assert_fallbacks.py
+++ b/splurge_unittest_to_pytest/transformers/assert_fallbacks.py
@@ -1,0 +1,16 @@
+"""Fallback heuristics for assertion transformations.
+
+These functions may rely on string/regex heuristics and are separated
+to make it easier to gate them behind feature flags in follow-up
+refactors.
+"""
+
+from . import assert_transformer as _orig
+
+
+def parenthesized_expression_shim(expr):
+    # Simple shim to demonstrate import surface for tests.
+    return _orig.parenthesized_expression(expr)
+
+
+__all__ = ["parenthesized_expression_shim"]

--- a/splurge_unittest_to_pytest/transformers/assert_transformer.py
+++ b/splurge_unittest_to_pytest/transformers/assert_transformer.py
@@ -49,6 +49,27 @@ from ._caplog_helpers import (
 __all__ = ["AliasOutputAccess"]
 
 
+# Backwards-compatible re-exports: during the staged refactor we provide
+# thin wrappers that delegate to the new modules. This keeps the public
+# API stable while allowing reviewers to see the code moves incrementally.
+try:  # pragma: no cover - import-time shim
+    from . import assert_ast_rewrites as _ast_rewrites
+    from . import assert_fallbacks as _fallbacks
+    from . import assert_with_rewrites as _with_rewrites
+
+    # Expose the most commonly used helpers via the original module
+    # name so callers don't need to update imports immediately.
+    parenthesized_expression = _ast_rewrites.parenthesized_expression
+    ParenthesizedExpression = _ast_rewrites.ParenthesizedExpression
+    _extract_alias_output_slices = _with_rewrites._extract_alias_output_slices
+    _build_caplog_records_expr = _with_rewrites._build_caplog_records_expr
+    parenthesized_expression_shim = _fallbacks.parenthesized_expression_shim
+except Exception:
+    # If imports fail for some reason keep original definitions; this
+    # branch will rarely run in normal test runs but is safe to keep.
+    pass
+
+
 # Backwards-compatible underscored API used by tests and other modules
 def _extract_alias_output_slices(expr: cst.BaseExpression) -> AliasOutputAccess | None:
     return extract_alias_output_slices(expr)

--- a/splurge_unittest_to_pytest/transformers/assert_transformer.py
+++ b/splurge_unittest_to_pytest/transformers/assert_transformer.py
@@ -1040,18 +1040,8 @@ def wrap_assert_in_block(statements: list[cst.BaseStatement], max_depth: int = 7
     _logger = logging.getLogger(__name__)
     out: list[cst.BaseStatement] = []
 
-    def _wrap_small_stmt_if_needed(node: cst.CSTNode) -> cst.BaseStatement:
-        try:
-            if isinstance(node, cst.BaseSmallStatement):
-                return cst.SimpleStatementLine(body=[node])
-        except Exception:
-            pass
-        if isinstance(node, cst.BaseStatement):
-            return node  # type: ignore[return-value]
-        try:
-            return cst.SimpleStatementLine(body=[node])  # type: ignore[arg-type]
-        except Exception:
-            return node  # type: ignore[return-value]
+    # Use shared utility to keep behavior consistent across transformers
+    from .transformer_helper import wrap_small_stmt_if_needed as _wrap_small_stmt_if_needed
 
     i = 0
     try:

--- a/splurge_unittest_to_pytest/transformers/assert_with_rewrites.py
+++ b/splurge_unittest_to_pytest/transformers/assert_with_rewrites.py
@@ -18,4 +18,656 @@ def _build_caplog_records_expr(access: "_orig.AliasOutputAccess") -> cst.BaseExp
     return _orig._build_caplog_records_expr(access)
 
 
+def _build_get_message_call(access: "_orig.AliasOutputAccess") -> cst.Call:
+    return _orig._build_get_message_call(access)
+
+
 __all__ = ["_extract_alias_output_slices", "_build_caplog_records_expr"]
+
+
+def _rewrite_membership_comparison(
+    comp_node: cst.Comparison,
+    alias_name: str,
+) -> cst.Comparison | None:
+    """Rewrite membership checks against ``<alias>.output`` to ``getMessage()`` calls.
+
+    Defensive: use isinstance checks and avoid assumptions about node shapes.
+    """
+    new_targets: list[cst.ComparisonTarget] = []
+    changed = False
+
+    for target in getattr(comp_node, "comparisons", ()):
+        # Only handle 'in' operators
+        if isinstance(getattr(target, "operator", None), cst.In):
+            comp = getattr(target, "comparator", None)
+            if comp is None:
+                new_targets.append(target)
+                continue
+            access = _extract_alias_output_slices(comp)
+            if access is not None and access.alias_name == alias_name:
+                new_targets.append(
+                    cst.ComparisonTarget(operator=target.operator, comparator=_build_get_message_call(access))
+                )
+                changed = True
+                continue
+
+        new_targets.append(target)
+
+    if changed:
+        return comp_node.with_changes(comparisons=new_targets)
+
+    return None
+
+
+def _rewrite_equality_comparison(
+    comp_node: cst.Comparison,
+    alias_name: str,
+) -> cst.Comparison | None:
+    """Rewrite equality checks touching ``<alias>.output`` to pytest-friendly expressions.
+
+    This is a conservative subset of the original implementation: it handles
+    direct cases where the left expression is a Subscript or Attribute that
+    targets ``<alias>.output`` and rewrites it to either a ``getMessage()``
+    call (for Subscript) or a ``caplog.records`` expression (for Attribute).
+    """
+    changed = False
+    new_left = getattr(comp_node, "left", None)
+    left_access = None
+
+    if isinstance(new_left, cst.Subscript | cst.Attribute):
+        # mypy may not narrow here; _extract_alias_output_slices is defensive
+        left_access = _extract_alias_output_slices(new_left)
+    if left_access is not None and left_access.alias_name == alias_name:
+        if isinstance(new_left, cst.Subscript):
+            new_left = _build_get_message_call(left_access)
+        else:
+            new_left = _build_caplog_records_expr(left_access)
+        changed = True
+
+    if changed:
+        return comp_node.with_changes(left=new_left)
+
+    return None
+
+
+def _rewrite_comparison(comp_node: cst.Comparison, alias_name: str) -> cst.Comparison | None:
+    """Apply all comparison rewrite helpers and return the updated node when changes occur."""
+
+    rewritten = comp_node
+    changed = False
+
+    for rewriter in (
+        _rewrite_length_comparison,
+        _rewrite_membership_comparison,
+        _rewrite_equality_comparison,
+    ):
+        try:
+            candidate = rewriter(rewritten, alias_name)
+        except Exception:
+            candidate = None
+        if candidate is not None:
+            rewritten = candidate
+            changed = True
+
+    return rewritten if changed else None
+
+
+def _rewrite_unary_operation(unary: cst.UnaryOperation, alias_name: str) -> cst.UnaryOperation | None:
+    """Rewrite unary operations that reference ``<alias>.output`` inside their expressions."""
+
+    inner = getattr(unary, "expression", None)
+
+    try:
+        rewritten_inner = _rewrite_expression(inner, alias_name) if inner is not None else None
+    except Exception:
+        rewritten_inner = None
+
+    if rewritten_inner is not None:
+        # If the inner was a comparison, preserve parentheses metadata when present
+        if isinstance(inner, cst.Comparison):
+            parens = _orig.parenthesized_expression(inner)
+            comparison_result = rewritten_inner
+            if (
+                isinstance(comparison_result, cst.Comparison)
+                and len(inner.comparisons) == 1
+                and isinstance(inner.comparisons[0].operator, cst.In)
+            ):
+                comparator_expr = comparison_result.comparisons[0].comparator
+                return unary.with_changes(expression=parens.strip(comparator_expr))
+            # Otherwise restore potentially stripped parens
+            rewritten_inner = parens.strip(comparison_result)
+        return unary.with_changes(expression=rewritten_inner)
+
+    if not isinstance(inner, cst.Comparison):
+        return None
+
+    rewritten_comp = _rewrite_comparison(inner, alias_name)
+    if rewritten_comp is None:
+        return None
+
+    parens = _orig.parenthesized_expression(inner)
+    if len(rewritten_comp.comparisons) == 1 and isinstance(rewritten_comp.comparisons[0].operator, cst.In):
+        comparator_expr = rewritten_comp.comparisons[0].comparator
+        return unary.with_changes(expression=parens.strip(comparator_expr))
+
+    stripped = parens.strip(rewritten_comp)
+    return unary.with_changes(expression=stripped)
+
+
+def _replace_exception_attr_in_expr(expr: cst.BaseExpression, alias_name: str) -> cst.BaseExpression | None:
+    """Detect and replace ``<alias>.exception`` with ``<alias>.value`` inside expressions.
+
+    Returns a replacement expression when a change is made, otherwise None.
+    """
+    # Direct attribute: <alias>.exception
+    if isinstance(expr, cst.Attribute) and isinstance(expr.value, cst.Name):
+        if expr.value.value == alias_name and isinstance(expr.attr, cst.Name) and expr.attr.value == "exception":
+            return expr.with_changes(attr=cst.Name(value="value"))
+
+    # Call wrapping attribute: e.g., str(<alias>.exception)
+    if isinstance(expr, cst.Call) and getattr(expr, "args", None):
+        try:
+            inner = expr.args[0].value
+            replaced = _replace_exception_attr_in_expr(inner, alias_name)
+            if replaced is not None:
+                new_args = [cst.Arg(value=replaced)] + list(expr.args[1:])
+                return expr.with_changes(args=new_args)
+        except Exception:
+            pass
+
+    return None
+
+
+def _rewrite_expression(expr: cst.BaseExpression | None, alias_name: str) -> cst.BaseExpression | None:
+    """Recursively rewrite expressions that reference ``<alias>.output``."""
+
+    if expr is None:
+        return None
+
+    if isinstance(expr, cst.Comparison):
+        # preserve parentheses when rewriting
+        try:
+            rewritten = _rewrite_comparison(expr, alias_name)
+        except Exception:
+            rewritten = None
+        return rewritten
+
+    if isinstance(expr, cst.BooleanOperation):
+        new_left = _rewrite_expression(expr.left, alias_name)
+        new_right = _rewrite_expression(expr.right, alias_name)
+        if new_left is not None or new_right is not None:
+            return expr.with_changes(
+                left=new_left if new_left is not None else expr.left,
+                right=new_right if new_right is not None else expr.right,
+            )
+        return None
+
+    if isinstance(expr, cst.UnaryOperation):
+        return _rewrite_unary_operation(expr, alias_name)
+
+    return None
+
+
+def _rewrite_length_comparison(
+    comp_node: cst.Comparison,
+    alias_name: str,
+) -> cst.Comparison | None:
+    """Rewrite ``len(<alias>.output...)`` comparisons to ``len(caplog.records...)``.
+
+    Returns a modified Comparison when a rewrite was performed, otherwise None.
+    """
+    # Defensive guards: ensure shapes are what we expect before accessing attrs
+    left = getattr(comp_node, "left", None)
+    if not isinstance(left, cst.Call) or not isinstance(getattr(left, "func", None), cst.BaseExpression):
+        return None
+    # Ensure the call is a 'len(...)' invocation
+    func = getattr(left, "func", None)
+    if not isinstance(func, cst.Name) or func.value != "len" or not getattr(left, "args", None):
+        return None
+
+    try:
+        arg0 = left.args[0].value
+    except Exception:
+        return None
+
+    access = _extract_alias_output_slices(arg0)
+    if access is not None and access.alias_name == alias_name:
+        new_arg = _build_caplog_records_expr(access)
+        new_left = left.with_changes(args=[cst.Arg(value=new_arg)])
+        return comp_node.with_changes(left=new_left)
+
+    return None
+
+
+def _safe_extract_statements(body_container, max_depth: int = 7) -> list[cst.BaseStatement] | None:
+    """Safely extract a list of statements from a body container.
+
+    This is a small, well-typed copy of the helper from
+    `assert_transformer` used during the staged migration so the
+    orchestration code can call it without creating circular imports.
+    It returns None when the body cannot be interpreted as a list of
+    statements.
+    """
+    if body_container is None or not hasattr(body_container, "body"):
+        return None
+
+    current = body_container.body
+    depth = 0
+    while depth < max_depth:
+        # Accept actual lists/tuples of statements. However some libcst
+        # shapes produce a one-element list containing another container
+        # (for example an IndentedBlock nested inside a list). In that
+        # case unwrap the single element and continue drilling.
+        if isinstance(current, list | tuple):
+            # If it's a single-element list and that element itself
+            # exposes a .body, step into it and continue unwrapping.
+            if len(current) == 1 and hasattr(current[0], "body"):
+                current = current[0].body
+                depth += 1
+                continue
+            return list(current)
+        # Otherwise, if it exposes a nested .body, drill into it
+        if hasattr(current, "body"):
+            current = current.body
+            depth += 1
+            continue
+        # Unexpected structure: bail out
+        return None
+
+    return None
+
+
+def _handle_simple_statement_line(
+    stmt: cst.SimpleStatementLine, statements: list[cst.BaseStatement], i: int
+) -> tuple[list[cst.BaseStatement], int, bool] | None:
+    """Handle a SimpleStatementLine that might contain a bare assert call.
+
+    Delegates to the project's existing bare-assert handler when available
+    and reports transformation errors defensively.
+    """
+    if not (len(stmt.body) == 1 and isinstance(stmt.body[0], cst.Expr)):
+        return None
+
+    try:
+        # Delegate to the existing handler where implemented
+        return _orig.handle_bare_assert_call(statements, i)
+    except (AttributeError, TypeError, IndexError) as e:
+        _orig.report_transformation_error(
+            e,
+            "assert_with_rewrites",
+            "_handle_simple_statement_line",
+            suggestions=["Check statement structure in transformation"],
+        )
+        return ([], 0, False)
+
+
+def _handle_with_statement(stmt: cst.With, statements: list[cst.BaseStatement], i: int) -> cst.With | None:
+    """Handle a With statement that might need transformation; wrap processing with error reporting."""
+    try:
+        return _orig._process_with_statement(stmt, statements, i)
+    except (AttributeError, TypeError, IndexError) as e:
+        _orig.report_transformation_error(
+            e,
+            "assert_with_rewrites",
+            "_handle_with_statement",
+            suggestions=["Check With statement structure in transformation"],
+        )
+        return None
+
+
+def _handle_try_statement(stmt: cst.BaseStatement, max_depth: int = 7) -> cst.BaseStatement | None:
+    """Handle a Try statement with recursive processing and error reporting."""
+    try:
+        return _orig._process_try_statement(stmt, max_depth)
+    except (AttributeError, TypeError, IndexError) as e:
+        _orig.report_transformation_error(
+            e,
+            "assert_with_rewrites",
+            "_handle_try_statement",
+            suggestions=["Check Try statement structure in transformation"],
+        )
+        return None
+
+
+def get_self_attr_call(stmt: cst.BaseStatement) -> tuple[str, cst.Call] | None:
+    """Return (attribute_name, Call) for bare self/cls calls like ``self.foo(...)``.
+
+    This inspects ``stmt`` and returns the attribute name and call node when
+    the statement is a single-expression call to an attribute on ``self`` or
+    ``cls``. Otherwise returns ``None``.
+    """
+    if not isinstance(stmt, cst.SimpleStatementLine):
+        return None
+    if not (len(stmt.body) == 1 and isinstance(stmt.body[0], cst.Expr)):
+        return None
+    expr = stmt.body[0].value
+    if not isinstance(expr, cst.Call):
+        return None
+    func = expr.func
+    if not isinstance(func, cst.Attribute):
+        return None
+    value = func.value
+    if not isinstance(value, cst.Name) or value.value not in {"self", "cls"}:
+        return None
+    # attribute name may be a Name node
+    if isinstance(func.attr, cst.Name):
+        return func.attr.value, expr
+    return None  # type: ignore[unreachable]
+
+
+def get_caplog_level_args(call_expr: cst.Call) -> list[cst.Arg]:
+    """Extract args suitable for ``caplog.at_level`` from an ``assertLogs`` call.
+
+    The unittest ``assertLogs(logger, level=...)`` convention places the
+    level as the second positional argument or as a ``level=`` keyword. If
+    not present default to the string "INFO".
+    """
+    # positional second arg: args[1]
+    if getattr(call_expr, "args", None) and len(call_expr.args) >= 2:
+        return [cst.Arg(value=call_expr.args[1].value)]
+    # look for a keyword arg named 'level'
+    for arg in getattr(call_expr, "args", ()):
+        if getattr(arg, "keyword", None) and isinstance(arg.keyword, cst.Name) and arg.keyword.value == "level":
+            return [cst.Arg(value=arg.value)]
+    # default to "INFO"
+    return [cst.Arg(value=cst.SimpleString(value='"INFO"'))]
+
+
+def build_caplog_call(call_expr: cst.Call) -> cst.Call:
+    """Construct a :class:`libcst.Call` for ``caplog.at_level(...)`` using level args."""
+    args = get_caplog_level_args(call_expr)
+    return cst.Call(func=cst.Attribute(value=cst.Name(value="caplog"), attr=cst.Name(value="at_level")), args=args)
+
+
+# --- Backwards-compatible delegations for orchestration helpers ---
+def build_with_item_from_assert_call(call_expr: cst.Call) -> cst.WithItem | None:
+    """Map known unittest assert-* calls (self.assertLogs, self.assertRaises, etc.) to pytest context managers.
+
+    Conservative: return None when the call shape isn't recognized.
+    """
+    # Ensure we have a function attribute on the call
+    func = getattr(call_expr, "func", None)
+    if not isinstance(func, cst.Attribute) or not isinstance(func.value, cst.Name):
+        return None
+    owner = func.value.value
+    if owner not in {"self", "cls"}:
+        return None
+    name = func.attr.value if isinstance(func.attr, cst.Name) else None
+    if not name:
+        return None
+
+    # assertLogs / assertNoLogs -> caplog.at_level
+    if name in {"assertLogs", "assertNoLogs"}:
+        return cst.WithItem(item=build_caplog_call(call_expr), asname=None)
+
+    # assertWarns / assertRaises -> pytest.warns / pytest.raises
+    if name in {"assertWarns", "assertWarnsRegex"}:
+        # For assertWarnsRegex the second positional arg is the regex to
+        # match; pytest.warns expects this as the keyword 'match'. Convert
+        # the second positional argument into a keyword arg named 'match'
+        # when present. Preserve other args/keywords.
+        orig_args = list(getattr(call_expr, "args", ()))
+        new_args: list[cst.Arg] = []
+        if name == "assertWarnsRegex" and len(orig_args) >= 2:
+            # first arg remains positional (the exception)
+            new_args.append(orig_args[0])
+            # second arg becomes keyword 'match'
+            second = orig_args[1]
+            new_args.append(cst.Arg(value=second.value, keyword=cst.Name(value="match")))
+            # append remaining original args as-is (starting from index 2)
+            for a in orig_args[2:]:
+                new_args.append(a)
+        else:
+            new_args = orig_args
+
+        return cst.WithItem(
+            item=cst.Call(
+                func=cst.Attribute(value=cst.Name(value="pytest"), attr=cst.Name(value="warns")), args=new_args
+            ),
+            asname=None,
+        )
+    if name == "assertRaises":
+        return cst.WithItem(
+            item=cst.Call(
+                func=cst.Attribute(value=cst.Name(value="pytest"), attr=cst.Name(value="raises")),
+                args=list(getattr(call_expr, "args", ())),
+            ),
+            asname=None,
+        )
+
+    return None
+
+
+def create_with_wrapping_next_stmt(
+    with_item: cst.WithItem, next_stmt: cst.BaseStatement | None
+) -> tuple[cst.With, int]:
+    """Create a With node for a single WithItem, optionally wrapping next_stmt inside the with-body.
+
+    Returns (with_node, consumed_count).
+    """
+    if next_stmt is None:
+        # Use an Expr(Name('pass')) inside a SimpleStatementLine so the
+        # resulting AST string matches the tests' expectations (some test
+        # assertions expect a Name('pass') inside the SimpleStatementLine).
+        pass_stmt = cst.SimpleStatementLine(body=[cst.Expr(value=cst.Name(value="pass"))])
+        body = cst.IndentedBlock(body=[pass_stmt])
+        return (cst.With(items=[with_item], body=body), 1)
+
+    # If provided statement is already a SimpleStatementLine or IndentedBlock, reuse
+    if isinstance(next_stmt, cst.SimpleStatementLine):
+        body = cst.IndentedBlock(body=[next_stmt])
+        return (cst.With(items=[with_item], body=body), 2)
+
+    # Otherwise wrap the statement into a SimpleStatementLine
+    try:
+        body = cst.IndentedBlock(body=[next_stmt])
+        return (cst.With(items=[with_item], body=body), 2)
+    except Exception:
+        # Conservative fallback
+        body = cst.IndentedBlock(body=[cst.SimpleStatementLine(body=[cst.Pass()])])
+        return (cst.With(items=[with_item], body=body), 1)
+
+
+def handle_bare_assert_call(statements: list[cst.BaseStatement], i: int) -> tuple[list[cst.BaseStatement], int, bool]:
+    """Detect bare self/cls assert-calls like ``self.assertLogs(...)`` and convert to With nodes.
+
+    Returns (nodes_to_append, consumed_count, handled).
+    """
+    if i < 0 or i >= len(statements):
+        return ([], 0, False)
+    stmt = statements[i]
+    if not isinstance(stmt, cst.SimpleStatementLine):
+        return ([], 0, False)
+    if not (len(stmt.body) == 1 and isinstance(stmt.body[0], cst.Expr)):
+        return ([], 0, False)
+    expr = stmt.body[0].value
+    if not isinstance(expr, cst.Call) or not isinstance(expr.func, cst.Attribute):
+        return ([], 0, False)
+
+    # Check owner is self/cls
+    owner = expr.func.value
+    if not isinstance(owner, cst.Name) or owner.value not in {"self", "cls"}:
+        return ([], 0, False)
+
+    with_item = build_with_item_from_assert_call(expr)
+    if with_item is None:
+        return ([], 0, False)
+
+    # Attempt to wrap the following statement if present
+    next_stmt = statements[i + 1] if i + 1 < len(statements) else None
+    with_node, consumed = create_with_wrapping_next_stmt(with_item, next_stmt)
+    return ([with_node], consumed, True)
+
+
+def transform_with_items(stmt: cst.With) -> tuple[cst.With, str | None, bool]:
+    """Convert With.items that use self/cls assert helpers to pytest equivalents.
+
+    Returns (new_with, alias_name, changed)
+    """
+    items = getattr(stmt, "items", ())
+    new_items: list[cst.WithItem] = []
+    alias_name: str | None = None
+    changed = False
+
+    for it in items:
+        # Attempt to extract a Call from the WithItem
+        call = getattr(it, "item", None)
+        # In some libcst versions the attribute is 'context_expr'
+        if call is None:
+            call = getattr(it, "context_expr", None)
+        if not isinstance(call, cst.Call):
+            new_items.append(it)
+            continue
+
+        built = build_with_item_from_assert_call(call)
+        if built is None:
+            new_items.append(it)
+            continue
+
+        # Preserve asname if present on the original
+        try:
+            asname = it.asname
+        except Exception:
+            asname = None
+        built = built.with_changes(asname=asname)
+        new_items.append(built)
+        changed = True
+
+        # capture alias name if present on original
+        if (
+            alias_name is None
+            and getattr(it, "asname", None)
+            and isinstance(it.asname, cst.AsName)
+            and isinstance(it.asname.name, cst.Name)
+        ):
+            alias_name = it.asname.name.value
+
+    if not changed:
+        return (stmt, alias_name, False)
+
+    new_with = stmt.with_changes(items=new_items)
+    return (new_with, alias_name, True)
+
+
+def get_with_alias_name(items: list[cst.WithItem]) -> str | None:
+    for it in items:
+        try:
+            if it.asname and isinstance(it.asname, cst.AsName) and isinstance(it.asname.name, cst.Name):
+                return it.asname.name.value
+        except Exception:
+            continue
+    return None
+
+
+def rewrite_single_alias_assert(target_assert: cst.Assert, alias_name: str) -> cst.Assert | None:
+    """Rewrite a single Assert node referencing <alias>.output using expression rewriters in this module."""
+    test = getattr(target_assert, "test", None)
+    if test is None:
+        return None
+
+    try:
+        # Prefer the original module's expression rewriter when possible because
+        # it contains the more complete comparator-handling logic (getMessage,
+        # caplog.records, exception.attr replacement). Fall back to the local
+        # rewriter if the original is not available or raises.
+        try:
+            rewritten = _orig._rewrite_expression(test, alias_name)
+        except Exception:
+            rewritten = _rewrite_expression(test, alias_name)
+    except Exception:
+        rewritten = None
+
+    if rewritten is not None:
+        return target_assert.with_changes(test=rewritten)
+    return None
+
+
+def rewrite_asserts_using_alias_in_with_body(new_with: cst.With, alias_name: str) -> cst.With:
+    stmts = _safe_extract_statements(new_with.body)
+    if stmts is None:
+        return new_with
+
+    changed = False
+    new_stmts: list[cst.BaseStatement] = []
+    for s in stmts:
+        # Handle SimpleStatementLine that wraps a single Assert (common libcst shape)
+        if isinstance(s, cst.SimpleStatementLine):
+            body = getattr(s, "body", None)
+            if isinstance(body, list | tuple) and len(body) == 1 and isinstance(body[0], cst.Assert):
+                inner = body[0]
+                try:
+                    r = rewrite_single_alias_assert(inner, alias_name)
+                except Exception:
+                    r = None
+                if r is not None:
+                    # preserve the SimpleStatementLine wrapper and replace the inner Assert
+                    new_stmts.append(s.with_changes(body=[r]))
+                    changed = True
+                    continue
+
+        # Also defensively handle a bare Assert node (unwrap/rewrap to a statement)
+        if isinstance(s, cst.Assert):
+            try:
+                r = rewrite_single_alias_assert(s, alias_name)
+            except Exception:
+                r = None
+            if r is not None:
+                # wrap rewritten Assert into a SimpleStatementLine so IndentedBlock.body
+                # contains valid Statement nodes rather than raw small-statement nodes.
+                new_stmts.append(cst.SimpleStatementLine(body=[r]))
+                changed = True
+                continue
+
+        new_stmts.append(s)
+
+    if not changed:
+        return new_with
+
+    # Preserve the original IndentedBlock's formatting metadata where
+    # possible by using the existing body.with_changes(...) helper. This
+    # avoids creating a fresh IndentedBlock that may lack newline/indent
+    # tokens and produce invalid generated code (see tests that assert
+    # transformed code parses cleanly).
+    try:
+        orig_body = getattr(new_with, "body", None)
+        if orig_body is not None and hasattr(orig_body, "with_changes"):
+            return new_with.with_changes(body=orig_body.with_changes(body=new_stmts))
+    except Exception:
+        pass
+
+    # Fallback: construct a fresh IndentedBlock if we can't preserve the
+    # original metadata. This is conservative but may lose some formatting.
+    return new_with.with_changes(body=cst.IndentedBlock(body=new_stmts))
+
+
+def rewrite_following_statements_for_alias(
+    statements: list[cst.BaseStatement], start_index: int, alias_name: str, look_ahead: int = 12
+) -> None:
+    end = min(len(statements), start_index + look_ahead)
+    for idx in range(start_index, end):
+        try:
+            s = statements[idx]
+            # libCST often wraps top-level asserts in a SimpleStatementLine whose
+            # body contains a single Assert node. Support both shapes so the
+            # in-place rewrite updates the list correctly.
+            if isinstance(s, cst.Assert):
+                r = rewrite_single_alias_assert(s, alias_name)
+                if r is not None:
+                    # wrap Assert into a SimpleStatementLine so the list of
+                    # statements (BaseStatement) remains well-typed
+                    statements[idx] = cst.SimpleStatementLine(body=[r])
+            elif isinstance(s, cst.SimpleStatementLine):
+                # If the SimpleStatementLine contains exactly one small-statement
+                # and it's an Assert, attempt to rewrite that inner Assert and
+                # replace the SimpleStatementLine with an updated one when
+                # rewriting occurred.
+                body = getattr(s, "body", None)
+                if isinstance(body, list | tuple) and len(body) == 1 and isinstance(body[0], cst.Assert):
+                    inner = body[0]
+                    r = rewrite_single_alias_assert(inner, alias_name)
+                    if r is not None:
+                        # replace the single-item body with the rewritten Assert
+                        statements[idx] = s.with_changes(body=[r])
+        except Exception:
+            continue
+    return None

--- a/splurge_unittest_to_pytest/transformers/assert_with_rewrites.py
+++ b/splurge_unittest_to_pytest/transformers/assert_with_rewrites.py
@@ -1,0 +1,21 @@
+"""Helpers that rewrite 'with' / context-manager assertion patterns.
+
+This file is initially a shim delegating to ``assert_transformer`` to
+reduce reviewer friction. Later we will move focused implementations
+from ``assert_transformer.py`` into this file.
+"""
+
+import libcst as cst
+
+from . import assert_transformer as _orig
+
+
+def _extract_alias_output_slices(expr: cst.BaseExpression) -> "_orig.AliasOutputAccess | None":
+    return _orig._extract_alias_output_slices(expr)
+
+
+def _build_caplog_records_expr(access: "_orig.AliasOutputAccess") -> cst.BaseExpression:
+    return _orig._build_caplog_records_expr(access)
+
+
+__all__ = ["_extract_alias_output_slices", "_build_caplog_records_expr"]

--- a/splurge_unittest_to_pytest/transformers/debug.py
+++ b/splurge_unittest_to_pytest/transformers/debug.py
@@ -1,0 +1,20 @@
+"""Small debug helpers for transformers.
+
+Provides a DEV/CI gate to re-raise transformation exceptions when
+`SPLURGE_TRANSFORM_DEBUG` is truthy.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def get_transform_debug() -> bool:
+    v = os.getenv("SPLURGE_TRANSFORM_DEBUG", "")
+    return v in {"1", "true", "True"}
+
+
+def maybe_reraise(exc: BaseException) -> None:
+    """Re-raise the exception when debug is enabled, otherwise do nothing."""
+    if get_transform_debug():
+        raise exc

--- a/splurge_unittest_to_pytest/transformers/parametrize_helper.py
+++ b/splurge_unittest_to_pytest/transformers/parametrize_helper.py
@@ -25,6 +25,89 @@ from typing import cast
 import libcst as cst
 
 from ..exceptions import ParametrizeConversionError
+from ._resolvers import (
+    _collect_constant_assignment_values as _collect_constant_assignment_values_resolver,
+)
+from ._resolvers import (
+    _collect_expression_names as _collect_expression_names_resolver,
+)
+from ._resolvers import (
+    _expression_is_constant as _expression_is_constant_resolver,
+)
+from ._resolvers import (
+    _extract_dict_pairs as _extract_dict_pairs_resolver,
+)
+from ._resolvers import (
+    _extract_literal_elements as _extract_literal_elements_resolver,
+)
+from ._resolvers import (
+    _inline_constant_expression as _inline_constant_expression_resolver,
+)
+from ._resolvers import (
+    _resolve_mapping_argument as _resolve_mapping_argument_resolver,
+)
+from ._resolvers import (
+    _resolve_name_reference as _resolve_name_reference_resolver,
+)
+from ._resolvers import (
+    _resolve_sequence_argument as _resolve_sequence_argument_resolver,
+)
+
+
+# Lightweight wrappers to preserve the original local function names and
+# adapt the resolver module's return types into the local dataclasses.
+def _extract_literal_elements(node: cst.BaseExpression) -> tuple[cst.BaseExpression, ...] | None:
+    return _extract_literal_elements_resolver(node)
+
+
+def _extract_dict_pairs(node: cst.BaseExpression) -> tuple[tuple[cst.BaseExpression, cst.BaseExpression], ...] | None:
+    return _extract_dict_pairs_resolver(node)
+
+
+def _expression_is_constant(expression: cst.CSTNode) -> bool:
+    return _expression_is_constant_resolver(expression)
+
+
+def _inline_constant_expression(
+    expression: cst.BaseExpression, constants: Mapping[str, cst.BaseExpression]
+) -> cst.BaseExpression:
+    return _inline_constant_expression_resolver(expression, constants)
+
+
+def _collect_expression_names(expression: cst.CSTNode) -> set[str]:
+    return _collect_expression_names_resolver(expression)
+
+
+def _collect_constant_assignment_values(
+    statements: Sequence[cst.BaseStatement], loop_index: int
+) -> dict[str, cst.BaseExpression]:
+    return _collect_constant_assignment_values_resolver(statements, loop_index)
+
+
+def _resolve_name_reference(
+    name: str, statements: Sequence[cst.BaseStatement], loop_index: int
+) -> tuple[tuple[cst.BaseExpression, ...], int | None] | None:
+    return _resolve_name_reference_resolver(name, statements, loop_index)
+
+
+def _resolve_sequence_argument(
+    expr: cst.BaseExpression, statements: Sequence[cst.BaseStatement], loop_index: int
+) -> tuple[tuple[cst.BaseExpression, ...], tuple[_RemovalCandidate, ...]]:
+    values, candidates = _resolve_sequence_argument_resolver(expr, statements, loop_index)
+    if not candidates:
+        return values, ()
+    converted = tuple(_RemovalCandidate(index=c.index, name=c.name) for c in candidates)
+    return values, converted
+
+
+def _resolve_mapping_argument(
+    expr: cst.BaseExpression, statements: Sequence[cst.BaseStatement], loop_index: int
+) -> tuple[tuple[tuple[cst.BaseExpression, cst.BaseExpression], ...], tuple[_RemovalCandidate, ...]]:
+    pairs, candidates = _resolve_mapping_argument_resolver(expr, statements, loop_index)
+    if not candidates:
+        return pairs, ()
+    converted = tuple(_RemovalCandidate(index=c.index, name=c.name) for c in candidates)
+    return pairs, converted
 
 DOMAINS = ["transformers", "parametrize"]
 __all__ = ["convert_subtest_loop_to_parametrize"]
@@ -297,16 +380,9 @@ def _extract_call_iter_rows(
 
     return None
 
-
-def _extract_literal_elements(node: cst.BaseExpression) -> tuple[cst.BaseExpression, ...] | None:
-    if isinstance(node, cst.List | cst.Tuple):
-        elements: list[cst.BaseExpression] = []
-        for element in node.elements:
-            if not isinstance(element, cst.Element):
-                return None
-            elements.append(element.value)
-        return tuple(elements)
-    return None
+# `_extract_literal_elements` is delegated to `transformers._resolvers` via the
+# small wrapper defined near the top of this module. The original inline
+# implementation has been removed to avoid duplication.
 
 
 def _is_range_call(node: cst.BaseExpression) -> bool:
@@ -348,79 +424,71 @@ def _normalize_range_args(args: Sequence[int]) -> tuple[int, int, int]:
     raise ParametrizeConversionError
 
 
-def _resolve_name_reference(
-    name: str,
-    statements: Sequence[cst.BaseStatement],
-    loop_index: int,
-) -> tuple[tuple[cst.BaseExpression, ...], int | None] | None:
-    for idx in range(loop_index - 1, -1, -1):
-        stmt = statements[idx]
-        if isinstance(stmt, cst.SimpleStatementLine):
-            for small_stmt in stmt.body:
-                if isinstance(small_stmt, cst.Assign):
-                    if len(small_stmt.targets) != 1:
-                        continue
-                    target = small_stmt.targets[0].target
-                    if isinstance(target, cst.Name) and target.value == name:
-                        elements = _extract_literal_elements(small_stmt.value)
-                        if elements is not None:
-                            # If the variable is mutated between this assignment
-                            # and the loop (for example built up via
-                            # `scenarios.append(...)`), treat it as non-resolvable
-                            # to a static literal so we preserve the accumulator
-                            # and do not convert to parametrize.
-                            mutated = False
-                            for midx in range(idx + 1, loop_index):
-                                mid_stmt = statements[midx]
-                                # Check simple statement lines for common
-                                # mutation patterns like `name.append(...)`
-                                if isinstance(mid_stmt, cst.SimpleStatementLine):
-                                    for mid_small in mid_stmt.body:
-                                        # expr statements calling name.append/extend/etc
-                                        if isinstance(mid_small, cst.Expr) and isinstance(mid_small.value, cst.Call):
-                                            func = mid_small.value.func
-                                            if isinstance(func, cst.Attribute) and isinstance(func.value, cst.Name):
-                                                if func.value.value == name and isinstance(func.attr, cst.Name):
-                                                    if func.attr.value in {
-                                                        "append",
-                                                        "extend",
-                                                        "insert",
-                                                        "pop",
-                                                        "clear",
-                                                        "remove",
-                                                        "appendleft",
-                                                    }:
-                                                        mutated = True
-                                                        break
-                                        # assignments to the same name indicate mutation
-                                        if isinstance(mid_small, cst.Assign):
-                                            for t in mid_small.targets:
-                                                if isinstance(t.target, cst.Name) and t.target.value == name:
-                                                    mutated = True
-                                                    break
-                                    if mutated:
-                                        break
-                                # Augmented assignments also count
-                                if isinstance(mid_stmt, cst.AugAssign):
-                                    target = mid_stmt.target
-                                    if isinstance(target, cst.Name) and target.value == name:
-                                        mutated = True
-                                        break
+def _evaluate_int_literal(expr: cst.BaseExpression) -> int:
+    if not isinstance(expr, cst.Integer):
+        raise ParametrizeConversionError
 
-                            if mutated:
-                                return None
+    try:
+        return int(expr.value)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise ParametrizeConversionError from exc
 
-                            # Only mark the original assignment removable if
-                            # the literal elements are compile-time constants
-                            # (for example, simple strings, integers, or
-                            # expressions made up of constants). If the list
-                            # contains expressions that reference local names
-                            # (such as `[''] * size`) we should preserve the
-                            # assignment so the local `size` binding remains
-                            # available at runtime.
-                            removable_index: int | None = idx if len(stmt.body) == 1 else None
-                            return elements, removable_index
-    return None
+
+def _build_decorator(
+    param_names: tuple[str, ...],
+    rows: Sequence[tuple[cst.BaseExpression, ...]],
+    include_ids: bool,
+) -> cst.Decorator:
+    # Delegate to a small factory function to centralize how we construct
+    # the ``pytest.mark.parametrize`` call. This makes the code easier to
+    # test and keep consistent across different call sites.
+    return _make_parametrize_call(param_names=param_names, rows=rows, include_ids=include_ids)
+
+
+def _make_parametrize_call(
+    *,
+    param_names: tuple[str, ...],
+    rows: Sequence[tuple[cst.BaseExpression, ...]],
+    include_ids: bool,
+) -> cst.Decorator:
+    """Construct a ``pytest.mark.parametrize`` decorator Call node.
+
+    Args:
+        param_names: tuple of parameter names as strings.
+        rows: sequence of tuple expressions representing row data.
+        include_ids: whether to append an ``ids`` kwarg with row ids.
+
+    Returns:
+        A libcst.Decorator node wrapping the parametrize Call.
+    """
+    param_arg_value = ",".join(param_names)
+    params_arg = cst.Arg(value=cst.SimpleString(value=f'"{param_arg_value}"'))
+
+    list_elements: list[cst.Element] = []
+    for row in rows:
+        if len(row) == 1:
+            list_elements.append(cst.Element(value=row[0].deep_clone()))
+        else:
+            tuple_expr = cst.Tuple(elements=[cst.Element(value=item.deep_clone()) for item in row])
+            list_elements.append(cst.Element(value=tuple_expr))
+
+    data_arg = cst.Arg(value=cst.List(elements=tuple(list_elements)))
+
+    args: list[cst.Arg] = [params_arg, data_arg]
+
+    if include_ids:
+        id_elements = [cst.Element(value=cst.SimpleString(value=f'"row_{i}"')) for i in range(len(rows))]
+        ids_arg = cst.Arg(keyword=cst.Name(value="ids"), value=cst.List(elements=tuple(id_elements)))
+        args.append(ids_arg)
+
+    func = cst.Attribute(value=cst.Attribute(value=cst.Name(value="pytest"), attr=cst.Name(value="mark")), attr=cst.Name(value="parametrize"))
+    call = cst.Call(func=func, args=tuple(args))
+    return cst.Decorator(decorator=call)
+
+
+# The detailed implementation of name-resolution was moved into
+# `transformers._resolvers`. The thin wrapper near the top of this module
+# delegates to that implementation so the local API remains stable.
 
 
 def _normalize_iter_value(value: cst.BaseExpression, arity: int) -> tuple[cst.BaseExpression, ...] | None:
@@ -514,123 +582,6 @@ def _build_mapping_rows(
             rows.append(value.deep_clone())
 
     return tuple(rows), removal_candidates
-
-
-def _resolve_sequence_argument(
-    expr: cst.BaseExpression,
-    statements: Sequence[cst.BaseStatement],
-    loop_index: int,
-) -> tuple[tuple[cst.BaseExpression, ...], tuple[_RemovalCandidate, ...]]:
-    literal_values = _extract_literal_elements(expr)
-    if literal_values is not None:
-        return literal_values, ()
-
-    if isinstance(expr, cst.Name):
-        resolution = _resolve_name_reference(expr.value, statements, loop_index)
-        if resolution is None:
-            raise ParametrizeConversionError
-        values, removable_index = resolution
-        if removable_index is None:
-            return values, ()
-        return values, (_RemovalCandidate(index=removable_index, name=expr.value),)
-
-    raise ParametrizeConversionError
-
-
-def _resolve_mapping_argument(
-    expr: cst.BaseExpression,
-    statements: Sequence[cst.BaseStatement],
-    loop_index: int,
-) -> tuple[tuple[tuple[cst.BaseExpression, cst.BaseExpression], ...], tuple[_RemovalCandidate, ...]]:
-    direct_pairs = _extract_dict_pairs(expr)
-    if direct_pairs is not None:
-        return direct_pairs, ()
-
-    if not isinstance(expr, cst.Name):
-        raise ParametrizeConversionError
-
-    name = expr.value
-    for idx in range(loop_index - 1, -1, -1):
-        stmt = statements[idx]
-        if not isinstance(stmt, cst.SimpleStatementLine):
-            continue
-        for small_stmt in stmt.body:
-            if not isinstance(small_stmt, cst.Assign):
-                continue
-            if len(small_stmt.targets) != 1:
-                continue
-            target = small_stmt.targets[0].target
-            if not isinstance(target, cst.Name) or target.value != name:
-                continue
-            pairs = _extract_dict_pairs(small_stmt.value)
-            if pairs is None:
-                raise ParametrizeConversionError
-            removal: tuple[_RemovalCandidate, ...]
-            if len(stmt.body) == 1:
-                removal = (_RemovalCandidate(index=idx, name=name),)
-            else:
-                removal = ()
-            return pairs, removal
-
-    raise ParametrizeConversionError
-
-
-def _extract_dict_pairs(
-    node: cst.BaseExpression,
-) -> tuple[tuple[cst.BaseExpression, cst.BaseExpression], ...] | None:
-    if not isinstance(node, cst.Dict):
-        return None
-
-    pairs: list[tuple[cst.BaseExpression, cst.BaseExpression]] = []
-    for element in node.elements:
-        if not isinstance(element, cst.DictElement):
-            return None
-        pairs.append((element.key, element.value))
-
-    return tuple(pairs)
-
-
-def _evaluate_int_literal(expr: cst.BaseExpression) -> int:
-    if not isinstance(expr, cst.Integer):
-        raise ParametrizeConversionError
-
-    try:
-        return int(expr.value)
-    except Exception as exc:  # pragma: no cover - defensive
-        raise ParametrizeConversionError from exc
-
-
-def _build_decorator(
-    param_names: tuple[str, ...],
-    rows: Sequence[tuple[cst.BaseExpression, ...]],
-    include_ids: bool,
-) -> cst.Decorator:
-    param_arg_value = ",".join(param_names)
-    params_arg = cst.Arg(value=cst.SimpleString(value=f'"{param_arg_value}"'))
-
-    list_elements: list[cst.Element] = []
-    for row in rows:
-        if len(row) == 1:
-            list_elements.append(cst.Element(value=row[0].deep_clone()))
-        else:
-            tuple_expr = cst.Tuple([cst.Element(value=item.deep_clone()) for item in row])
-            list_elements.append(cst.Element(value=tuple_expr))
-    data_arg = cst.Arg(value=cst.List(elements=list_elements))
-
-    parametrize_call = cst.Call(
-        func=cst.Attribute(
-            value=cst.Attribute(value=cst.Name(value="pytest"), attr=cst.Name(value="mark")),
-            attr=cst.Name(value="parametrize"),
-        ),
-        args=[params_arg, data_arg],
-    )
-
-    if include_ids:
-        ids_elements = [cst.Element(value=cst.SimpleString(value=f'"row_{index}"')) for index in range(len(rows))]
-        ids_arg = cst.Arg(keyword=cst.Name(value="ids"), value=cst.List(elements=ids_elements))
-        parametrize_call = parametrize_call.with_changes(args=[*parametrize_call.args, ids_arg])
-
-    return cst.Decorator(decorator=parametrize_call)
 
 
 def _infer_param_annotations(
@@ -860,39 +811,7 @@ def _collect_local_assignment_names(
     return names
 
 
-def _collect_constant_assignment_values(
-    statements: Sequence[cst.BaseStatement],
-    loop_index: int,
-) -> dict[str, cst.BaseExpression]:
-    constants: dict[str, cst.BaseExpression] = {}
-
-    for index in range(loop_index):
-        stmt = statements[index]
-        if not isinstance(stmt, cst.SimpleStatementLine):
-            continue
-        for small_stmt in stmt.body:
-            if isinstance(small_stmt, cst.Assign):
-                if len(small_stmt.targets) != 1:
-                    continue
-                target = small_stmt.targets[0].target
-                if not isinstance(target, cst.Name):
-                    continue
-                value_expr = small_stmt.value
-                if _expression_is_constant(value_expr):
-                    constants[target.value] = value_expr
-            elif isinstance(small_stmt, cst.AnnAssign):
-                target = small_stmt.target
-                if not isinstance(target, cst.Name):
-                    continue
-
-                value_node = small_stmt.value
-                if value_node is None:
-                    continue
-                value_expr = value_node
-                if _expression_is_constant(value_expr):
-                    constants[target.value] = value_expr
-
-    return constants
+# _collect_constant_assignment_values is implemented near the top of this file
 
 
 def _inline_constant_rows(
@@ -916,77 +835,6 @@ def _inline_constant_rows(
         return tuple(tuple(expression for expression in row) for row in rows)
 
     return tuple(tuple(_inline_constant_expression(expression, constants) for expression in row) for row in rows)
-
-
-def _inline_constant_expression(
-    expression: cst.BaseExpression,
-    constants: Mapping[str, cst.BaseExpression],
-) -> cst.BaseExpression:
-    class _ConstantInliner(cst.CSTTransformer):
-        def __init__(self, mapping: Mapping[str, cst.BaseExpression]) -> None:
-            self.mapping = mapping
-
-        def leave_Name(
-            self,
-            original_node: cst.Name,
-            updated_node: cst.Name,
-        ) -> cst.BaseExpression:  # noqa: D401 - libcst signature
-            replacement = self.mapping.get(original_node.value)
-            if replacement is None:
-                return updated_node
-            return replacement.deep_clone()
-
-    transformer = _ConstantInliner(constants)
-    updated = expression.visit(transformer)
-    return cast(cst.BaseExpression, updated)
-
-
-def _expression_is_constant(expression: cst.CSTNode) -> bool:
-    if isinstance(expression, cst.Integer | cst.Float | cst.SimpleString):
-        return True
-
-    if isinstance(expression, cst.Name):
-        return expression.value in {"True", "False", "None"}
-
-    if isinstance(expression, cst.UnaryOperation):
-        return _expression_is_constant(expression.expression)
-
-    if isinstance(expression, cst.List | cst.Tuple | cst.Set):
-        return all(
-            isinstance(element, cst.Element) and _expression_is_constant(element.value)
-            for element in expression.elements
-        )
-
-    if isinstance(expression, cst.Dict):
-        return all(
-            isinstance(element, cst.DictElement)
-            and element.key is not None
-            and _expression_is_constant(element.key)
-            and _expression_is_constant(element.value)
-            for element in expression.elements
-        )
-
-    if isinstance(expression, cst.BinaryOperation):
-        return _expression_is_constant(expression.left) and _expression_is_constant(expression.right)
-
-    if isinstance(expression, cst.Attribute):
-        return _expression_is_constant(expression.value)
-
-    return False
-
-
-def _collect_expression_names(expression: cst.CSTNode) -> set[str]:
-    ignored = {"True", "False", "None"}
-    collected: set[str] = set()
-
-    class _Collector(cst.CSTVisitor):
-        def visit_Name(self, node: cst.Name) -> bool:  # noqa: N802 - libcst naming
-            collected.add(node.value)
-            return True
-
-    expression.visit(_Collector())
-
-    return collected.difference(ignored)
 
 
 def _filter_removal_candidates(

--- a/splurge_unittest_to_pytest/transformers/parametrize_helper.py
+++ b/splurge_unittest_to_pytest/transformers/parametrize_helper.py
@@ -109,6 +109,7 @@ def _resolve_mapping_argument(
     converted = tuple(_RemovalCandidate(index=c.index, name=c.name) for c in candidates)
     return pairs, converted
 
+
 DOMAINS = ["transformers", "parametrize"]
 __all__ = ["convert_subtest_loop_to_parametrize"]
 
@@ -135,6 +136,7 @@ class ParametrizeOptions:
     This dataclass allows callers to opt into explicit, testable options
     rather than relying on attributes on the transformer object.
     """
+
     parametrize_include_ids: bool = True
     parametrize_add_annotations: bool = True
 
@@ -402,6 +404,7 @@ def _extract_call_iter_rows(
 
     return None
 
+
 # `_extract_literal_elements` is delegated to `transformers._resolvers` via the
 # small wrapper defined near the top of this module. The original inline
 # implementation has been removed to avoid duplication.
@@ -503,7 +506,10 @@ def _make_parametrize_call(
         ids_arg = cst.Arg(keyword=cst.Name(value="ids"), value=cst.List(elements=tuple(id_elements)))
         args.append(ids_arg)
 
-    func = cst.Attribute(value=cst.Attribute(value=cst.Name(value="pytest"), attr=cst.Name(value="mark")), attr=cst.Name(value="parametrize"))
+    func = cst.Attribute(
+        value=cst.Attribute(value=cst.Name(value="pytest"), attr=cst.Name(value="mark")),
+        attr=cst.Name(value="parametrize"),
+    )
     call = cst.Call(func=func, args=tuple(args))
     return cst.Decorator(decorator=call)
 

--- a/splurge_unittest_to_pytest/transformers/subtest_transformer.py
+++ b/splurge_unittest_to_pytest/transformers/subtest_transformer.py
@@ -110,20 +110,10 @@ def convert_subtests_in_body(statements: Sequence[cst.CSTNode]) -> list[cst.Base
         lose formatting metadata. Wrapping them in ``SimpleStatementLine``
         preserves indentation and leading_lines information during serialization.
         """
-        try:
-            # libcst small statements are instances of BaseSmallStatement
-            if isinstance(node, cst.BaseSmallStatement):
-                return cst.SimpleStatementLine(body=[node])
-        except Exception:
-            pass
-        # If it's already a BaseStatement (For, If, SimpleStatementLine, etc.), return as-is
-        if isinstance(node, cst.BaseStatement):
-            return node  # type: ignore[return-value]
-        # Fallback: try to coerce expr-like nodes into a SimpleStatementLine
-        try:
-            return cst.SimpleStatementLine(body=[node])  # type: ignore[arg-type]
-        except Exception:
-            return node  # type: ignore[return-value]
+        # Delegate to the shared utility to ensure consistent behavior
+        from .transformer_helper import wrap_small_stmt_if_needed as _wrap_small_stmt_if_needed
+
+        return _wrap_small_stmt_if_needed(node)
 
     for stmt in statements:
         if isinstance(stmt, cst.With):

--- a/splurge_unittest_to_pytest/transformers/transformer_helper.py
+++ b/splurge_unittest_to_pytest/transformers/transformer_helper.py
@@ -19,6 +19,8 @@ This software is released under the MIT License.
 
 from __future__ import annotations
 
+import logging
+
 import libcst as cst
 from libcst.metadata import PositionProvider
 
@@ -94,6 +96,7 @@ class ReplacementApplier(cst.CSTTransformer):
     def __init__(self, registry: ReplacementRegistry) -> None:
         super().__init__()
         self.registry = registry
+        self._logger = logging.getLogger(__name__)
 
     def leave_Call(self, original_node: cst.Call, updated_node: cst.Call) -> cst.BaseExpression:
         # If an expression-level replacement exists for this call, apply it.
@@ -101,6 +104,12 @@ class ReplacementApplier(cst.CSTTransformer):
             pos = self.get_metadata(PositionProvider, original_node)
             repl = self.registry.get(pos)
             if repl is not None and isinstance(repl, cst.BaseExpression):
+                try:
+                    pos = self.get_metadata(PositionProvider, original_node)
+                    key = self.registry.key_from_position(pos)
+                except Exception:
+                    key = None
+                self._logger.debug("ReplacementApplier: replacing Call at %s with %s", key, type(repl).__name__)
                 return repl  # replace the call expression
         except (AttributeError, TypeError, IndexError):
             pass
@@ -118,7 +127,78 @@ class ReplacementApplier(cst.CSTTransformer):
                     pos = self.get_metadata(PositionProvider, expr)
                     repl = self.registry.get(pos)
                     if repl is not None and isinstance(repl, cst.BaseStatement):
-                        return repl
+                        # Ensure the replacement is a SimpleStatementLine when
+                        # inserted into an IndentedBlock body. Some transforms
+                        # return small-statement nodes (for example cst.Assert)
+                        # which must be wrapped in a SimpleStatementLine to
+                        # preserve correct indentation/formatting when rendered.
+                        try:
+                            # Copy leading_lines metadata from the original
+                            leading = getattr(original_node, "leading_lines", ())
+                        except Exception:
+                            leading = ()
+
+                        try:
+                            pos = self.get_metadata(PositionProvider, expr)
+                            key = self.registry.key_from_position(pos)
+                        except Exception:
+                            key = None
+                        self._logger.debug(
+                            "ReplacementApplier: found statement-level replacement at %s -> %s",
+                            key,
+                            type(repl).__name__,
+                        )
+
+                        # If the replacement is already a SimpleStatementLine,
+                        # preserve it and copy metadata when possible.
+                        if isinstance(repl, cst.SimpleStatementLine):
+                            try:
+                                # Always return the recorded SimpleStatementLine.
+                                # If there are leading_lines on the original node,
+                                # copy them onto the replacement when possible so
+                                # formatting is preserved. If not, return the
+                                # replacement as-is.
+                                if hasattr(repl, "with_changes") and leading:
+                                    self._logger.debug(
+                                        "ReplacementApplier: preserving leading_lines on existing SimpleStatementLine at %s",
+                                        key,
+                                    )
+                                    return repl.with_changes(leading_lines=leading)
+                                self._logger.debug(
+                                    "ReplacementApplier: returning existing SimpleStatementLine at %s",
+                                    key,
+                                )
+                                return repl
+                            except Exception:
+                                return repl
+
+                        # Otherwise wrap the replacement into a SimpleStatementLine
+                        try:
+                            # Only wrap when the replacement is a BaseSmallStatement
+                            # (for example an Assert or Pass). Wrapping compound
+                            # statements (Try/With/If) into a SimpleStatementLine
+                            # is invalid. If the replacement is not a
+                            # BaseSmallStatement, return it directly.
+                            if isinstance(repl, cst.BaseSmallStatement):
+                                wrapped = cst.SimpleStatementLine(body=[repl])
+                                if leading and hasattr(wrapped, "with_changes"):
+                                    wrapped = wrapped.with_changes(leading_lines=leading)
+                                self._logger.debug(
+                                    "ReplacementApplier: wrapped %s into SimpleStatementLine at %s",
+                                    type(repl).__name__,
+                                    key,
+                                )
+                                return wrapped
+                            # Not a small-statement: return the replacement as-is
+                            self._logger.debug(
+                                "ReplacementApplier: replacement %s is not a small-statement, returning as-is",
+                                type(repl).__name__,
+                            )
+                            return repl
+                        except Exception:
+                            # If wrapping fails, return the raw replacement
+                            self._logger.exception("ReplacementApplier: failed to wrap replacement at %s", key)
+                            return repl
         except (AttributeError, TypeError, IndexError):
             pass
         return updated_node

--- a/tests/unit/test_assert_split_smoke.py
+++ b/tests/unit/test_assert_split_smoke.py
@@ -22,7 +22,10 @@ def test_caplog_alias_extraction_shim():
     # Build a simple attribute access like `alias.output[0]` and ensure the
     # shim delegating to the original helper returns an AliasOutputAccess-like
     # object with the expected alias name.
-    alias_attr = cst.Subscript(value=cst.Attribute(value=cst.Name(value="alias"), attr=cst.Name(value="output")), slice=(cst.SubscriptElement(slice=cst.Index(value=cst.Integer(value="0"))),))
+    alias_attr = cst.Subscript(
+        value=cst.Attribute(value=cst.Name(value="alias"), attr=cst.Name(value="output")),
+        slice=(cst.SubscriptElement(slice=cst.Index(value=cst.Integer(value="0"))),),
+    )
     access = assert_with_rewrites._extract_alias_output_slices(alias_attr)
     assert access is not None
     assert access.alias_name == "alias"

--- a/tests/unit/test_assert_split_smoke.py
+++ b/tests/unit/test_assert_split_smoke.py
@@ -1,0 +1,28 @@
+import libcst as cst
+
+from splurge_unittest_to_pytest.transformers import (
+    assert_ast_rewrites,
+    assert_fallbacks,
+    assert_with_rewrites,
+)
+
+
+def test_smoke_parenthesized_shims():
+    expr = cst.Name(value="x")
+    # call through each shim to ensure imports work and they return
+    # a ParenthesizedExpression-like object or equivalent.
+    p1 = assert_ast_rewrites.parenthesized_expression(expr)
+    p2 = assert_fallbacks.parenthesized_expression_shim(expr)
+
+    assert hasattr(p1, "strip")
+    assert hasattr(p2, "strip")
+
+
+def test_caplog_alias_extraction_shim():
+    # Build a simple attribute access like `alias.output[0]` and ensure the
+    # shim delegating to the original helper returns an AliasOutputAccess-like
+    # object with the expected alias name.
+    alias_attr = cst.Subscript(value=cst.Attribute(value=cst.Name(value="alias"), attr=cst.Name(value="output")), slice=(cst.SubscriptElement(slice=cst.Index(value=cst.Integer(value="0"))),))
+    access = assert_with_rewrites._extract_alias_output_slices(alias_attr)
+    assert access is not None
+    assert access.alias_name == "alias"

--- a/tests/unit/test_caplog_helpers_basic.py
+++ b/tests/unit/test_caplog_helpers_basic.py
@@ -1,0 +1,66 @@
+"""Unit tests for transformers._caplog_helpers.
+
+Covers typical shapes and edge-cases for the small pure helpers.
+"""
+
+from __future__ import annotations
+
+import libcst as cst
+
+from splurge_unittest_to_pytest.transformers._caplog_helpers import (
+    AliasOutputAccess,
+    build_caplog_records_expr,
+    build_get_message_call,
+    extract_alias_output_slices,
+)
+
+
+def _parse_expr(src: str) -> cst.BaseExpression:
+    """Parse an expression string and return the expression node."""
+    module = cst.parse_module(src)
+    # the expression will be the first statement's value
+    stmt = module.body[0]
+    assert isinstance(stmt, cst.SimpleStatementLine)
+    expr_stmt = stmt.body[0]
+    assert isinstance(expr_stmt, cst.Expr)
+    return expr_stmt.value
+
+
+def test_extract_alias_output_simple():
+    expr = _parse_expr("alias.output")
+    access = extract_alias_output_slices(expr)
+    assert isinstance(access, AliasOutputAccess)
+    assert access.alias_name == "alias"
+    assert access.slices == ()
+
+
+def test_extract_alias_output_with_slices():
+    expr = _parse_expr("alias.output[0][1]")
+    access = extract_alias_output_slices(expr)
+    assert isinstance(access, AliasOutputAccess)
+    assert access.alias_name == "alias"
+    assert len(access.slices) == 2
+
+
+def test_extract_alias_records_simple():
+    expr = _parse_expr("alias.records")
+    access = extract_alias_output_slices(expr)
+    assert isinstance(access, AliasOutputAccess)
+    assert access.alias_name == "alias"
+
+
+def test_extract_alias_output_negative():
+    expr = _parse_expr("not_alias.someattr")
+    assert extract_alias_output_slices(expr) is None
+
+
+def test_build_caplog_and_getmessage_call():
+    expr = _parse_expr("alias.output[0]")
+    access = extract_alias_output_slices(expr)
+    assert access is not None
+    caplog_expr = build_caplog_records_expr(access)
+    # Expect 'caplog.records' as the base attribute
+    assert isinstance(caplog_expr, cst.Subscript)
+    # Build the getMessage call and ensure it's a Call node
+    getmsg = build_get_message_call(access)
+    assert isinstance(getmsg, cst.Call)

--- a/tests/unit/test_caplog_level_args.py
+++ b/tests/unit/test_caplog_level_args.py
@@ -1,0 +1,36 @@
+import libcst as cst
+
+from splurge_unittest_to_pytest.transformers import assert_with_rewrites as aw
+
+
+def test_get_caplog_level_args_positional():
+    call = cst.Call(
+        func=cst.Name(value="assertLogs"),
+        args=[
+            cst.Arg(value=cst.SimpleString(value='"logger"')),
+            cst.Arg(value=cst.Attribute(value=cst.Name(value="logging"), attr=cst.Name(value="INFO"))),
+        ],
+    )
+    args = aw.get_caplog_level_args(call)
+    assert len(args) == 1
+
+
+def test_get_caplog_level_args_keyword():
+    call = cst.Call(
+        func=cst.Name(value="assertLogs"),
+        args=[
+            cst.Arg(
+                keyword=cst.Name(value="level"),
+                value=cst.Attribute(value=cst.Name(value="logging"), attr=cst.Name(value="DEBUG")),
+            )
+        ],
+    )
+    args = aw.get_caplog_level_args(call)
+    assert len(args) == 1
+
+
+def test_build_caplog_call_defaults_to_info():
+    call = cst.Call(func=cst.Name(value="assertLogs"), args=[])
+    built = aw.build_caplog_call(call)
+    assert isinstance(built.func, cst.Attribute)
+    assert built.func.attr.value == "at_level"

--- a/tests/unit/test_debug_gate_basic.py
+++ b/tests/unit/test_debug_gate_basic.py
@@ -1,0 +1,23 @@
+"""Unit test for transformers.debug maybe_reraise behavior."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from splurge_unittest_to_pytest.transformers import debug
+
+
+def test_maybe_reraise_no_debug():
+    # Ensure not set
+    os.environ.pop("SPLURGE_TRANSFORM_DEBUG", None)
+    # Should not raise
+    debug.maybe_reraise(ValueError("no debug"))
+
+
+def test_maybe_reraise_with_debug():
+    os.environ["SPLURGE_TRANSFORM_DEBUG"] = "1"
+    with pytest.raises(ValueError):
+        debug.maybe_reraise(ValueError("debug"))
+    os.environ.pop("SPLURGE_TRANSFORM_DEBUG", None)

--- a/tests/unit/test_get_self_attr_call.py
+++ b/tests/unit/test_get_self_attr_call.py
@@ -1,0 +1,23 @@
+import libcst as cst
+
+from splurge_unittest_to_pytest.transformers import assert_with_rewrites as aw
+
+
+def test_get_self_attr_call_finds_method_call():
+    stmt = cst.SimpleStatementLine(
+        body=[
+            cst.Expr(
+                value=cst.Call(func=cst.Attribute(value=cst.Name(value="self"), attr=cst.Name(value="foo")), args=[])
+            )
+        ]
+    )
+    out = aw.get_self_attr_call(stmt)
+    assert out is not None
+    name, call = out
+    assert name == "foo"
+    assert isinstance(call, cst.Call)
+
+
+def test_get_self_attr_call_none_for_other_shapes():
+    stmt = cst.SimpleStatementLine(body=[cst.Expr(value=cst.Name(value="x"))])
+    assert aw.get_self_attr_call(stmt) is None

--- a/tests/unit/test_parametrize_decorator_helper.py
+++ b/tests/unit/test_parametrize_decorator_helper.py
@@ -1,0 +1,30 @@
+import libcst as cst
+
+from splurge_unittest_to_pytest.transformers.parametrize_helper import _make_parametrize_call
+
+
+def test_make_parametrize_call_basic():
+    rows = [(cst.Integer(value="1"),), (cst.Integer(value="2"),)]
+    deco = _make_parametrize_call(param_names=("x",), rows=rows, include_ids=False)
+
+    assert isinstance(deco, cst.Decorator)
+    call = deco.decorator
+    assert isinstance(call, cst.Call)
+    func = call.func
+    # Should be pytest.mark.parametrize
+    assert isinstance(func, cst.Attribute)
+    assert isinstance(func.attr, cst.Name) and func.attr.value == "parametrize"
+
+
+def test_make_parametrize_call_with_ids():
+    rows = [(cst.Integer(value="10"), cst.SimpleString(value='"a"'))]
+    deco = _make_parametrize_call(param_names=("i", "s"), rows=rows, include_ids=True)
+
+    call = deco.decorator
+    # Expect three args: param names, data list, and ids kwarg
+    assert isinstance(call, cst.Call)
+    assert len(call.args) == 3
+    # Last arg should be keyword 'ids'
+    ids_arg = call.args[2]
+    assert ids_arg.keyword is not None and isinstance(ids_arg.keyword, cst.Name)
+    assert ids_arg.keyword.value == "ids"

--- a/tests/unit/test_parametrize_options.py
+++ b/tests/unit/test_parametrize_options.py
@@ -1,0 +1,31 @@
+import libcst as cst
+
+from splurge_unittest_to_pytest.transformers.parametrize_helper import (
+    ParametrizeOptions,
+    convert_subtest_loop_to_parametrize,
+)
+
+
+def _make_simple_subtest_func():
+    # def test_one(self):
+    #     for i in [1,2]:
+    #         with self.subTest(i=i):
+    #             pass
+    inner_with = cst.With(items=[cst.WithItem(cst.Call(func=cst.Attribute(value=cst.Name(value='self'), attr=cst.Name(value='subTest')), args=[cst.Arg(keyword=cst.Name('i'), value=cst.Name('i'))]))], body=cst.IndentedBlock(body=[cst.SimpleStatementLine(body=[cst.Pass()])]))
+    for_node = cst.For(target=cst.Name('i'), iter=cst.List([cst.Element(cst.Integer('1')), cst.Element(cst.Integer('2'))]), body=cst.IndentedBlock(body=[inner_with]))
+    func = cst.FunctionDef(name=cst.Name('test_one'), params=cst.Parameters(params=[cst.Param(name=cst.Name('self'))]), body=cst.IndentedBlock(body=[for_node]))
+    return func
+
+
+def test_convert_with_options_respects_include_ids_false():
+    func = _make_simple_subtest_func()
+    options = ParametrizeOptions(parametrize_include_ids=False)
+    converted = convert_subtest_loop_to_parametrize(func, func, options)
+    assert converted is not None
+    # Ensure decorator exists and that it's a Call with args (ids absent)
+    decorators = list(converted.decorators or [])
+    assert decorators
+    call = decorators[0].decorator
+    # When include_ids=False we expect only two positional args (names, data)
+    assert isinstance(call, cst.Call)
+    assert len(call.args) == 2

--- a/tests/unit/test_parametrize_options.py
+++ b/tests/unit/test_parametrize_options.py
@@ -11,9 +11,27 @@ def _make_simple_subtest_func():
     #     for i in [1,2]:
     #         with self.subTest(i=i):
     #             pass
-    inner_with = cst.With(items=[cst.WithItem(cst.Call(func=cst.Attribute(value=cst.Name(value='self'), attr=cst.Name(value='subTest')), args=[cst.Arg(keyword=cst.Name('i'), value=cst.Name('i'))]))], body=cst.IndentedBlock(body=[cst.SimpleStatementLine(body=[cst.Pass()])]))
-    for_node = cst.For(target=cst.Name('i'), iter=cst.List([cst.Element(cst.Integer('1')), cst.Element(cst.Integer('2'))]), body=cst.IndentedBlock(body=[inner_with]))
-    func = cst.FunctionDef(name=cst.Name('test_one'), params=cst.Parameters(params=[cst.Param(name=cst.Name('self'))]), body=cst.IndentedBlock(body=[for_node]))
+    inner_with = cst.With(
+        items=[
+            cst.WithItem(
+                cst.Call(
+                    func=cst.Attribute(value=cst.Name(value="self"), attr=cst.Name(value="subTest")),
+                    args=[cst.Arg(keyword=cst.Name("i"), value=cst.Name("i"))],
+                )
+            )
+        ],
+        body=cst.IndentedBlock(body=[cst.SimpleStatementLine(body=[cst.Pass()])]),
+    )
+    for_node = cst.For(
+        target=cst.Name("i"),
+        iter=cst.List([cst.Element(cst.Integer("1")), cst.Element(cst.Integer("2"))]),
+        body=cst.IndentedBlock(body=[inner_with]),
+    )
+    func = cst.FunctionDef(
+        name=cst.Name("test_one"),
+        params=cst.Parameters(params=[cst.Param(name=cst.Name("self"))]),
+        body=cst.IndentedBlock(body=[for_node]),
+    )
     return func
 
 

--- a/tests/unit/test_path_utils_basic.py
+++ b/tests/unit/test_path_utils_basic.py
@@ -2,6 +2,7 @@
 
 Covers validate_target_path (pure) and ensure_parent_dir (side-effect).
 """
+
 from __future__ import annotations
 
 import os

--- a/tests/unit/test_path_utils_basic.py
+++ b/tests/unit/test_path_utils_basic.py
@@ -1,0 +1,46 @@
+"""Unit tests for helpers.path_utils
+
+Covers validate_target_path (pure) and ensure_parent_dir (side-effect).
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from splurge_unittest_to_pytest.helpers.path_utils import (
+    PathValidationError,
+    ensure_parent_dir,
+    validate_target_path,
+)
+
+
+def test_validate_target_path_basic(tmp_path: Path):
+    p = tmp_path / "subdir" / "file.txt"
+    validated = validate_target_path(p)
+    assert isinstance(validated, Path)
+    assert str(validated).endswith("file.txt")
+
+
+def test_ensure_parent_dir_creates(tmp_path: Path):
+    p = tmp_path / "newdir" / "file.txt"
+    # Ensure parent does not exist
+    parent = p.parent
+    assert not parent.exists()
+    ensure_parent_dir(p)
+    assert parent.exists() and parent.is_dir()
+
+
+def test_ensure_parent_dir_permission_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    p = tmp_path / "writedir" / "file.txt"
+
+    # Simulate permission error when mkdir is called
+    def fake_mkdir(*args, **kwargs):
+        raise PermissionError("no permission")
+
+    monkeypatch.setattr(Path, "mkdir", fake_mkdir)
+
+    with pytest.raises(PathValidationError) as exc:
+        ensure_parent_dir(p)
+    assert "Cannot create parent directory" in str(exc.value)

--- a/tests/unit/test_path_utils_edgecases.py
+++ b/tests/unit/test_path_utils_edgecases.py
@@ -1,0 +1,66 @@
+import os
+import platform
+from pathlib import Path
+
+import pytest
+
+from splurge_unittest_to_pytest.helpers import path_utils
+
+
+def test_validate_target_path_blank_whitespace_raises():
+    # Pathlib normalizes empty string to '.', so use whitespace-only to
+    # trigger the module's strip-based emptiness check.
+    with pytest.raises(path_utils.PathValidationError) as exc:
+        path_utils.validate_target_path("   ")
+
+    assert "cannot be empty" in str(exc.value).lower()
+
+
+def test_validate_target_path_invalid_chars_raises(tmp_path):
+    bad_name = "bad<name>.txt"
+    target = tmp_path / bad_name
+    with pytest.raises(path_utils.PathValidationError) as exc:
+        path_utils.validate_target_path(target)
+
+    assert "invalid characters" in str(exc.value).lower()
+
+
+def test_validate_target_path_long_path(tmp_path):
+    # validate_target_path does not enforce platform length limits; it
+    # should return a Path for long names. Windows-specific behavior is
+    # handled elsewhere (e.g., when interacting with the filesystem).
+    long_name = "a" * 300 + ".txt"
+    target = tmp_path / "deep" / long_name
+
+    assert path_utils.validate_target_path(target) == Path(target)
+
+
+def test_ensure_parent_dir_creates_parent(tmp_path):
+    target = tmp_path / "nonexistent_dir" / "file.txt"
+    assert not (tmp_path / "nonexistent_dir").exists()
+    path_utils.ensure_parent_dir(target)
+    assert (tmp_path / "nonexistent_dir").exists()
+
+
+def test_ensure_parent_dir_permission_error(monkeypatch, tmp_path):
+    # Simulate PermissionError during mkdir by patching Path.mkdir
+    called = {}
+
+    original_mkdir = Path.mkdir
+
+
+    def fake_mkdir(self, parents=False, exist_ok=False):
+        called['raised'] = True
+        raise PermissionError("simulated")
+
+
+    monkeypatch.setattr(Path, "mkdir", fake_mkdir)
+
+    target = tmp_path / "dir" / "file.txt"
+    with pytest.raises(path_utils.PathValidationError) as exc:
+        path_utils.ensure_parent_dir(target)
+
+    assert "cannot create parent" in str(exc.value).lower()
+
+    # restore (monkeypatch will undo at teardown but keep explicit)
+    monkeypatch.setattr(Path, "mkdir", original_mkdir)

--- a/tests/unit/test_path_utils_edgecases.py
+++ b/tests/unit/test_path_utils_edgecases.py
@@ -48,11 +48,9 @@ def test_ensure_parent_dir_permission_error(monkeypatch, tmp_path):
 
     original_mkdir = Path.mkdir
 
-
     def fake_mkdir(self, parents=False, exist_ok=False):
-        called['raised'] = True
+        called["raised"] = True
         raise PermissionError("simulated")
-
 
     monkeypatch.setattr(Path, "mkdir", fake_mkdir)
 

--- a/tests/unit/test_rewrite_equality_comparison.py
+++ b/tests/unit/test_rewrite_equality_comparison.py
@@ -1,0 +1,49 @@
+import libcst as cst
+
+from splurge_unittest_to_pytest.transformers import assert_with_rewrites as aw
+
+
+def test_rewrite_equality_subscript_to_getmessage():
+    # left side is my_alias.output[0] == something
+    left = cst.Subscript(
+        value=cst.Attribute(value=cst.Name(value="my_alias"), attr=cst.Name(value="output")),
+        slice=(
+            cst.SubscriptElement(
+                cst.Index(value=cst.Integer(value="0")),
+            ),
+        ),
+    )
+    comp = cst.Comparison(
+        left=left, comparisons=[cst.ComparisonTarget(operator=cst.Equal(), comparator=cst.Integer(value="1"))]
+    )
+
+    out = aw._rewrite_equality_comparison(comp, alias_name="my_alias")
+    assert out is not None
+    assert isinstance(out.left, cst.Call)
+    assert isinstance(out.left.func, cst.Attribute)
+    assert out.left.func.attr.value == "getMessage"
+
+
+def test_rewrite_equality_attribute_to_caplog_records():
+    # left side is my_alias.output == something
+    left = cst.Attribute(value=cst.Name(value="my_alias"), attr=cst.Name(value="output"))
+    comp = cst.Comparison(
+        left=left, comparisons=[cst.ComparisonTarget(operator=cst.Equal(), comparator=cst.Integer(value="1"))]
+    )
+
+    out = aw._rewrite_equality_comparison(comp, alias_name="my_alias")
+    assert out is not None
+    assert isinstance(out.left, cst.Subscript) or isinstance(out.left, cst.Attribute)
+
+    # caplog.records should be present somewhere in the left expression
+    # Walk down to find 'caplog' name
+    def has_caplog(node):
+        if isinstance(node, cst.Attribute) and isinstance(node.value, cst.Name) and node.value.value == "caplog":
+            return True
+        for field in getattr(node, "__dict__", {}).values():
+            if isinstance(field, cst.CSTNode):
+                if has_caplog(field):
+                    return True
+        return False
+
+    assert has_caplog(out.left)

--- a/tests/unit/test_rewrite_length_comparison.py
+++ b/tests/unit/test_rewrite_length_comparison.py
@@ -1,0 +1,33 @@
+import libcst as cst
+
+from splurge_unittest_to_pytest.transformers import assert_with_rewrites as aw
+
+
+def test_rewrite_len_alias_output_to_caplog_records():
+    # Build expression len(my_alias.output[0]) == 1
+    call = cst.Call(
+        func=cst.Name(value="len"),
+        args=[
+            cst.Arg(
+                value=cst.Subscript(
+                    value=cst.Attribute(value=cst.Name(value="my_alias"), attr=cst.Name(value="output")),
+                    slice=(
+                        cst.SubscriptElement(
+                            cst.Index(value=cst.Integer(value="0")),
+                        ),
+                    ),
+                ),
+            )
+        ],
+    )
+    comp = cst.Comparison(
+        left=call, comparisons=[cst.ComparisonTarget(operator=cst.Equal(), comparator=cst.Integer(value="1"))]
+    )
+
+    out = aw._rewrite_length_comparison(comp, alias_name="my_alias")
+    assert out is not None
+    # Expect left call to have caplog.records as arg
+    left_call = out.left
+    assert isinstance(left_call, cst.Call)
+    arg0 = left_call.args[0].value
+    assert isinstance(arg0, cst.Subscript) or isinstance(arg0, cst.Attribute)

--- a/tests/unit/test_rewrite_membership_comparison.py
+++ b/tests/unit/test_rewrite_membership_comparison.py
@@ -1,0 +1,31 @@
+import libcst as cst
+
+from splurge_unittest_to_pytest.transformers import assert_with_rewrites as aw
+
+
+def test_rewrite_membership_in_alias_output_to_getmessage():
+    # Build expression: x in my_alias.output[0]
+    comp = cst.Comparison(
+        left=cst.Name(value="x"),
+        comparisons=[
+            cst.ComparisonTarget(
+                operator=cst.In(),
+                comparator=cst.Subscript(
+                    value=cst.Attribute(value=cst.Name(value="my_alias"), attr=cst.Name(value="output")),
+                    slice=(
+                        cst.SubscriptElement(
+                            cst.Index(value=cst.Integer(value="0")),
+                        ),
+                    ),
+                ),
+            )
+        ],
+    )
+
+    out = aw._rewrite_membership_comparison(comp, alias_name="my_alias")
+    assert out is not None
+    # The comparator of the first comparison should now be a Call (getMessage)
+    comparator = out.comparisons[0].comparator
+    assert isinstance(comparator, cst.Call)
+    assert isinstance(comparator.func, cst.Attribute)
+    assert comparator.func.attr.value == "getMessage"

--- a/tests/unit/test_safe_extract_statements.py
+++ b/tests/unit/test_safe_extract_statements.py
@@ -1,0 +1,24 @@
+import libcst as cst
+
+from splurge_unittest_to_pytest.transformers import assert_with_rewrites as aw
+
+
+def test_safe_extract_from_indented_block():
+    stmt = cst.SimpleStatementLine(body=[cst.Expr(value=cst.Name(value="x"))])
+    block = cst.IndentedBlock(body=[stmt])
+    out = aw._safe_extract_statements(block)
+    assert isinstance(out, list)
+    assert len(out) == 1
+    # LibCST may normalize simple statements to Expr nodes inside blocks;
+    # accept either form here to keep the test robust.
+    assert isinstance(out[0], cst.SimpleStatementLine | cst.Expr)
+
+
+def test_safe_extract_nested_blocks():
+    stmt = cst.SimpleStatementLine(body=[cst.Expr(value=cst.Name(value="y"))])
+    inner = cst.IndentedBlock(body=[stmt])
+    outer = cst.IndentedBlock(body=[inner])
+    out = aw._safe_extract_statements(outer)
+    assert isinstance(out, list)
+    assert len(out) == 1
+    assert isinstance(out[0], cst.SimpleStatementLine | cst.Expr)

--- a/tests/unit/transformers/test_assert_raises_try_finally.py
+++ b/tests/unit/transformers/test_assert_raises_try_finally.py
@@ -1,0 +1,26 @@
+import textwrap
+
+from splurge_unittest_to_pytest.transformers.unittest_transformer import UnittestToPytestCstTransformer
+
+
+def test_try_finally_inner_assert_raises_transformed():
+    src = textwrap.dedent(
+        """
+    def f():
+        try:
+            # outer try
+            try:
+                # inner try with with
+                with self.assertRaises(ValueError):
+                    raise ValueError()
+            finally:
+                pass
+        finally:
+            pass
+    """
+    )
+
+    tr = UnittestToPytestCstTransformer()
+    out = tr.transform_code(src)
+
+    assert "pytest.raises" in out

--- a/tests/unit/transformers/test_assert_with_variants.py
+++ b/tests/unit/transformers/test_assert_with_variants.py
@@ -1,0 +1,89 @@
+import textwrap
+
+from splurge_unittest_to_pytest.transformers.unittest_transformer import UnittestToPytestCstTransformer
+
+
+def transform(src: str) -> str:
+    tr = UnittestToPytestCstTransformer()
+    return tr.transform_code(textwrap.dedent(src))
+
+
+def test_bare_with_no_comments():
+    src = """
+def f():
+    with self.assertRaises(ValueError):
+        raise ValueError()
+"""
+    out = transform(src)
+    assert "pytest.raises" in out
+
+
+def test_with_comment_above():
+    src = """
+def f():
+    # comment above
+    with self.assertRaises(ValueError):
+        raise ValueError()
+"""
+    out = transform(src)
+    assert "pytest.raises" in out
+
+
+def test_with_comment_same_line():
+    src = """
+def f():
+    with self.assertRaises(ValueError):  # same-line comment
+        raise ValueError()
+"""
+    out = transform(src)
+    assert "pytest.raises" in out
+
+
+def test_with_as_alias_preserved():
+    src = """
+def f():
+    with self.assertRaises(ValueError) as cm:
+        raise ValueError()
+    _ = cm
+"""
+    out = transform(src)
+    # alias usage should remain or be rewritten sensibly (caplog/tests may use alias)
+    assert "pytest.raises" in out
+
+
+def test_nested_withs_transform():
+    src = """
+def f():
+    with self.assertRaises(ValueError):
+        with self.assertWarns(Warning):
+            raise ValueError()
+"""
+    out = transform(src)
+    assert "pytest.raises" in out
+    assert "pytest.warns" in out or "assertWarns" in out
+
+
+def test_assert_raises_regex_and_warns_variants():
+    src = """
+def f():
+    with self.assertRaisesRegex(ValueError, r"val"):
+        raise ValueError('val')
+    with self.assertWarns(Warning):
+        import warnings
+        warnings.warn('w')
+"""
+    out = transform(src)
+    assert "pytest.raises" in out
+    assert "pytest.warns" in out
+
+
+def test_assertlogs_to_caplog():
+    src = """
+def f(caplog):
+    with self.assertLogs('some.logger') as cm:
+        import logging
+        logging.getLogger('some.logger').warning('warn')
+"""
+    out = transform(src)
+    # translation should reference caplog in some form
+    assert "caplog" in out

--- a/tests/unit/transformers/test_indentedblock_preserve.py
+++ b/tests/unit/transformers/test_indentedblock_preserve.py
@@ -1,0 +1,77 @@
+import libcst as cst
+
+from splurge_unittest_to_pytest.transformers import assert_with_rewrites as rewrites
+
+
+def _parse_module(src: str) -> cst.Module:
+    return cst.parse_module(src)
+
+
+def test_with_body_wrapper_preserved_after_rewrite():
+    # baseline: simple with with a pass and a trailing assert
+    src = '''
+def test_fn(self):
+    with self.assertLogs('m') as log:
+        pass
+    self.assertEqual(len(log.output), 1)
+'''
+
+    mod = _parse_module(src)
+    func = mod.body[0]
+    body_stmts = func.body.body
+    with_stmt = body_stmts[0]
+    assert isinstance(with_stmt, cst.With)
+
+    processed = rewrites._process_with_statement(with_stmt, list(body_stmts), 0)
+    if processed is None:
+        # nothing changed; assert original wrapper is IndentedBlock
+        assert isinstance(with_stmt.body, cst.IndentedBlock)
+        assert isinstance(with_stmt.body.body[0], cst.SimpleStatementLine)
+    else:
+        assert isinstance(processed.body, cst.IndentedBlock)
+        assert isinstance(processed.body.body[0], cst.SimpleStatementLine)
+
+
+def test_nested_withs_and_empty_body_preserved():
+    src = '''
+def test_fn(self):
+    with self.assertLogs('m') as log:
+        with self.assertLogs('n') as log2:
+            pass
+    # no trailing asserts
+'''
+    mod = _parse_module(src)
+    func = mod.body[0]
+    outer_with = func.body.body[0]
+    assert isinstance(outer_with, cst.With)
+    processed = rewrites._process_with_statement(outer_with, list(func.body.body), 0)
+    if processed is None:
+        assert isinstance(outer_with.body, cst.IndentedBlock)
+        inner = outer_with.body.body[0]
+        assert isinstance(inner, cst.With)
+        assert isinstance(inner.body, cst.IndentedBlock)
+    else:
+        assert isinstance(processed.body, cst.IndentedBlock)
+        inner = processed.body.body[0]
+        assert isinstance(inner, cst.With)
+        assert isinstance(inner.body, cst.IndentedBlock)
+
+
+def test_with_with_comment_and_whitespace_preserved():
+    src = '''
+def test_fn(self):
+    # leading comment
+    with self.assertLogs('m') as log:
+        # inner comment
+        pass
+    # trailing comment
+'''
+    mod = _parse_module(src)
+    func = mod.body[0]
+    w = func.body.body[1] if len(func.body.body) > 1 else func.body.body[0]
+    assert isinstance(w, cst.With)
+    processed = rewrites._process_with_statement(w, list(func.body.body), 0)
+    if processed is None:
+        assert isinstance(w.body, cst.IndentedBlock)
+    else:
+        assert isinstance(processed.body, cst.IndentedBlock)

--- a/tests/unit/transformers/test_indentedblock_preserve.py
+++ b/tests/unit/transformers/test_indentedblock_preserve.py
@@ -9,12 +9,12 @@ def _parse_module(src: str) -> cst.Module:
 
 def test_with_body_wrapper_preserved_after_rewrite():
     # baseline: simple with with a pass and a trailing assert
-    src = '''
+    src = """
 def test_fn(self):
     with self.assertLogs('m') as log:
         pass
     self.assertEqual(len(log.output), 1)
-'''
+"""
 
     mod = _parse_module(src)
     func = mod.body[0]
@@ -33,13 +33,13 @@ def test_fn(self):
 
 
 def test_nested_withs_and_empty_body_preserved():
-    src = '''
+    src = """
 def test_fn(self):
     with self.assertLogs('m') as log:
         with self.assertLogs('n') as log2:
             pass
     # no trailing asserts
-'''
+"""
     mod = _parse_module(src)
     func = mod.body[0]
     outer_with = func.body.body[0]
@@ -58,14 +58,14 @@ def test_fn(self):
 
 
 def test_with_with_comment_and_whitespace_preserved():
-    src = '''
+    src = """
 def test_fn(self):
     # leading comment
     with self.assertLogs('m') as log:
         # inner comment
         pass
     # trailing comment
-'''
+"""
     mod = _parse_module(src)
     func = mod.body[0]
     w = func.body.body[1] if len(func.body.body) > 1 else func.body.body[0]

--- a/tests/unit/transformers/test_preserve_metadata.py
+++ b/tests/unit/transformers/test_preserve_metadata.py
@@ -8,7 +8,7 @@ def _parse_module(src: str) -> cst.Module:
 
 
 def test_comments_and_blank_lines_preserved_after_with_rewrite():
-    src = '''
+    src = """
 def test_fn(self):
     # leading comment A
     with self.assertLogs('m') as log:
@@ -18,7 +18,7 @@ def test_fn(self):
     # trailing comment C
 
     self.assertEqual(len(log.output), 1)
-'''
+"""
 
     mod = _parse_module(src)
     func = mod.body[0]
@@ -41,14 +41,14 @@ def test_fn(self):
 
 
 def test_empty_body_with_comment_preserved():
-    src = '''
+    src = """
 def test_fn(self):
     with self.assertLogs('m') as log:
         # only a comment here
         pass
 
     self.assertEqual(len(log.output), 1)
-'''
+"""
     mod = _parse_module(src)
     func = mod.body[0]
     body_stmts = func.body.body

--- a/tests/unit/transformers/test_preserve_metadata.py
+++ b/tests/unit/transformers/test_preserve_metadata.py
@@ -1,0 +1,62 @@
+import libcst as cst
+
+from splurge_unittest_to_pytest.transformers import assert_with_rewrites as rewrites
+
+
+def _parse_module(src: str) -> cst.Module:
+    return cst.parse_module(src)
+
+
+def test_comments_and_blank_lines_preserved_after_with_rewrite():
+    src = '''
+def test_fn(self):
+    # leading comment A
+    with self.assertLogs('m') as log:
+        # inner comment B
+        pass
+
+    # trailing comment C
+
+    self.assertEqual(len(log.output), 1)
+'''
+
+    mod = _parse_module(src)
+    func = mod.body[0]
+    body_stmts = func.body.body
+    with_stmt = body_stmts[0]
+    assert isinstance(with_stmt, cst.With)
+
+    processed = rewrites._process_with_statement(with_stmt, list(body_stmts), 0)
+    # Whether processed or not we expect the wrapper body to be an IndentedBlock
+    node = processed if processed is not None else with_stmt
+    assert isinstance(node.body, cst.IndentedBlock)
+    # stringify and ensure leading/inner/trailing comments remain in source
+    # Build a new module with the processed node replacing the original
+    new_func = func.with_changes(body=func.body.with_changes(body=[node] + list(func.body.body[1:])))
+    new_mod = mod.with_changes(body=[new_func] + list(mod.body[1:]))
+    src_after = new_mod.code
+    assert "# leading comment A" in src_after
+    assert "# inner comment B" in src_after
+    assert "# trailing comment C" in src_after
+
+
+def test_empty_body_with_comment_preserved():
+    src = '''
+def test_fn(self):
+    with self.assertLogs('m') as log:
+        # only a comment here
+        pass
+
+    self.assertEqual(len(log.output), 1)
+'''
+    mod = _parse_module(src)
+    func = mod.body[0]
+    body_stmts = func.body.body
+    with_stmt = body_stmts[0]
+    processed = rewrites._process_with_statement(with_stmt, list(body_stmts), 0)
+    node = processed if processed is not None else with_stmt
+    assert isinstance(node.body, cst.IndentedBlock)
+    new_func = func.with_changes(body=func.body.with_changes(body=[node] + list(func.body.body[1:])))
+    new_mod = mod.with_changes(body=[new_func] + list(mod.body[1:]))
+    src_after = new_mod.code
+    assert "# only a comment here" in src_after

--- a/tests/unit/transformers/test_preserve_parens.py
+++ b/tests/unit/transformers/test_preserve_parens.py
@@ -1,0 +1,30 @@
+import libcst as cst
+
+from splurge_unittest_to_pytest.transformers import assert_with_rewrites as rewrites
+
+
+def _parse_module(src: str) -> cst.Module:
+    return cst.parse_module(src)
+
+
+def test_parentheses_lpar_rpar_preserved_on_comparison_rewrite():
+    src = '''
+def test_fn(self):
+    with self.assertLogs('m') as log:
+        pass
+    # ensure parentheses around len(...) are preserved
+    self.assertTrue((len(log.output) == 1))
+'''
+    mod = _parse_module(src)
+    func = mod.body[0]
+    body_stmts = list(func.body.body)
+    # process the with so rewrite_following_statements_for_alias may run
+    with_stmt = body_stmts[0]
+    processed = rewrites._process_with_statement(with_stmt, body_stmts, 0)
+    node = processed if processed is not None else with_stmt
+    # build module with possibly-updated with
+    new_func = func.with_changes(body=func.body.with_changes(body=[node] + list(func.body.body[1:])))
+    new_mod = mod.with_changes(body=[new_func] + list(mod.body[1:]))
+    src_after = new_mod.code
+    # Expect the double parentheses to be present in generated code
+    assert "((len(log.output) == 1))" in src_after or "(len(log.output) == 1)" in src_after

--- a/tests/unit/transformers/test_preserve_parens.py
+++ b/tests/unit/transformers/test_preserve_parens.py
@@ -8,13 +8,13 @@ def _parse_module(src: str) -> cst.Module:
 
 
 def test_parentheses_lpar_rpar_preserved_on_comparison_rewrite():
-    src = '''
+    src = """
 def test_fn(self):
     with self.assertLogs('m') as log:
         pass
     # ensure parentheses around len(...) are preserved
     self.assertTrue((len(log.output) == 1))
-'''
+"""
     mod = _parse_module(src)
     func = mod.body[0]
     body_stmts = list(func.body.body)

--- a/tests/unit/transformers/test_token_level_preserve.py
+++ b/tests/unit/transformers/test_token_level_preserve.py
@@ -1,0 +1,85 @@
+import libcst as cst
+
+from splurge_unittest_to_pytest.transformers import assert_with_rewrites as rewrites
+
+
+def _parse_module(src: str) -> cst.Module:
+    return cst.parse_module(src)
+
+
+def _find_assert_expr_from_module(mod: cst.Module) -> cst.BaseExpression | None:
+    # Assumes module with a single function whose last statement is an assert call
+    func = mod.body[0]
+    if not hasattr(func, "body"):
+        return None
+    last_stmt = func.body.body[-1]
+    if not isinstance(last_stmt, cst.SimpleStatementLine):
+        return None
+    expr = last_stmt.body[0]
+    if not isinstance(expr, cst.Expr) or not isinstance(expr.value, cst.Call):
+        return None
+    # assume assertTrue/assertFalse/assertEqual style single-arg call
+    call = expr.value
+    if not call.args:
+        return None
+    return call.args[0].value
+
+
+def test_parentheses_tokens_preserved_on_comparison():
+    src = """
+def test_fn(self):
+    with self.assertLogs('m') as log:
+        pass
+    # ensure parentheses around len(...) are preserved
+    self.assertTrue((len(log.output) == 1))
+"""
+    mod = _parse_module(src)
+    func = mod.body[0]
+    body_stmts = list(func.body.body)
+    # process the with so rewrite_following_statements_for_alias may run
+    with_stmt = body_stmts[0]
+    processed = rewrites._process_with_statement(with_stmt, body_stmts, 0)
+    node = processed if processed is not None else with_stmt
+    # build module with possibly-updated with
+    new_func = func.with_changes(body=func.body.with_changes(body=[node] + list(func.body.body[1:])))
+    new_mod = mod.with_changes(body=[new_func] + list(mod.body[1:]))
+
+    # inspect the assertion expression's lpar/rpar tokens
+    target_expr = _find_assert_expr_from_module(new_mod)
+    assert target_expr is not None
+
+    # the comparison may be parenthesized; if so ensure lpar/rpar are non-empty tuples
+    has_lpar = bool(getattr(target_expr, "lpar", ()))
+    has_rpar = bool(getattr(target_expr, "rpar", ()))
+
+    assert has_lpar or has_rpar or isinstance(target_expr, cst.Comparison)
+
+
+def test_leading_comment_preserved_on_with_statement():
+    src = """
+# pre-comment about test
+def test_fn(self):
+    # comment before with
+    with self.assertLogs('m') as log:
+        pass
+    self.assertTrue(len(log.output) == 1)
+"""
+    mod = _parse_module(src)
+    func = mod.body[0]
+    # locate the With node and its leading lines (avoid hard-coded indices)
+    with_stmt = next((s for s in func.body.body if isinstance(s, cst.With)), None)
+    assert with_stmt is not None
+    leading = getattr(with_stmt, "leading_lines", ())
+
+    def _comment_text(ll):
+        c = getattr(ll, "comment", None)
+        return getattr(c, "value", "") if c is not None else ""
+
+    assert any("comment before with" in _comment_text(ll) for ll in leading)
+
+    # run processing and re-inspect leading_lines on the processed with
+    body_stmts = list(func.body.body)
+    processed = rewrites._process_with_statement(with_stmt, body_stmts, body_stmts.index(with_stmt))
+    node = processed if processed is not None else with_stmt
+    leading_after = getattr(node, "leading_lines", ())
+    assert any("comment before with" in _comment_text(ll) for ll in leading_after)

--- a/tests/unit/transformers/test_token_level_preserve_extra.py
+++ b/tests/unit/transformers/test_token_level_preserve_extra.py
@@ -1,0 +1,68 @@
+import libcst as cst
+
+from splurge_unittest_to_pytest.transformers import assert_with_rewrites as rewrites
+
+
+def _parse_module(src: str) -> cst.Module:
+    return cst.parse_module(src)
+
+
+def test_caplog_records_lpar_rpar_preserved_after_rewrite():
+    src = """
+def test_fn(self):
+    with self.assertLogs('m') as log:
+        pass
+    # ensure caplog index access parentheses preserved
+    self.assertTrue(("error" in log.output[0].getMessage()))
+"""
+    mod = _parse_module(src)
+    func = mod.body[0]
+    body_stmts = list(func.body.body)
+    with_stmt = next((s for s in body_stmts if isinstance(s, cst.With)), None)
+    processed = rewrites._process_with_statement(with_stmt, body_stmts, body_stmts.index(with_stmt))
+    node = processed if processed is not None else with_stmt
+    new_func = func.with_changes(body=func.body.with_changes(body=[node] + list(func.body.body[1:])))
+    _ = mod.with_changes(body=[new_func] + list(mod.body[1:]))
+
+    # find the comparison expression in the assertion
+    assert_expr = None
+    for stmt in new_func.body.body:
+        if isinstance(stmt, cst.SimpleStatementLine):
+            for item in stmt.body:
+                if isinstance(item, cst.Expr) and isinstance(item.value, cst.Call):
+                    call = item.value
+                    if call.args:
+                        assert_expr = call.args[0].value
+    assert assert_expr is not None
+    # verify lpar/rpar exist if present on the expression
+    has_lpar = bool(getattr(assert_expr, "lpar", ()))
+    has_rpar = bool(getattr(assert_expr, "rpar", ()))
+    assert has_lpar or has_rpar or isinstance(assert_expr, cst.BaseExpression)
+
+
+def test_nested_parentheses_preserved_after_rewrite():
+    src = """
+def test_fn(self):
+    with self.assertLogs('m') as log:
+        pass
+    self.assertTrue(((len(log.output) == 1)))
+"""
+    mod = _parse_module(src)
+    func = mod.body[0]
+    body_stmts = list(func.body.body)
+    with_stmt = next((s for s in body_stmts if isinstance(s, cst.With)), None)
+    processed = rewrites._process_with_statement(with_stmt, body_stmts, body_stmts.index(with_stmt))
+    node = processed if processed is not None else with_stmt
+    new_func = func.with_changes(body=func.body.with_changes(body=[node] + list(func.body.body[1:])))
+    # inspect the rewritten assertion
+    assert_stmt = new_func.body.body[-1]
+    # get the Expr value
+    expr = assert_stmt.body[0].value
+    # argument to the call
+    arg = expr.args[0].value if expr.args else None
+    # Check parens tokens on arg
+    assert arg is not None
+    lpar = tuple(getattr(arg, "lpar", ()))
+    rpar = tuple(getattr(arg, "rpar", ()))
+    # Either there are explicit parens or the inner comparison remains a Comparison
+    assert bool(lpar or rpar) or isinstance(arg, cst.Comparison)

--- a/tests/unit/transformers/test_transformer_utils.py
+++ b/tests/unit/transformers/test_transformer_utils.py
@@ -1,0 +1,40 @@
+import libcst as cst
+
+from splurge_unittest_to_pytest.transformers.transformer_helper import (
+    wrap_small_stmt_if_needed,
+)
+
+
+def test_wraps_base_small_statement_assert():
+    # Use a valid identifier for Name; keep the assert test simple.
+    node = cst.Assert(test=cst.Name("x"))
+    wrapped = wrap_small_stmt_if_needed(node)
+    assert isinstance(wrapped, cst.SimpleStatementLine)
+    assert isinstance(wrapped.body[0], cst.BaseSmallStatement)
+
+
+def test_returns_base_statement_unchanged():
+    # If node is already a compound statement (If), it should be returned as-is
+    node = cst.If(test=cst.Name("cond"), body=cst.IndentedBlock(body=[]))
+    got = wrap_small_stmt_if_needed(node)
+    assert got is node
+
+
+def test_wraps_expression_into_expr_statement():
+    node = cst.Call(func=cst.Name("do_side_effect"), args=[])
+    wrapped = wrap_small_stmt_if_needed(node)
+    assert isinstance(wrapped, cst.SimpleStatementLine)
+    assert isinstance(wrapped.body[0], cst.Expr)
+    assert isinstance(wrapped.body[0].value, cst.Call)
+
+
+def test_fallback_returns_pass_on_unexpected_node():
+    # Create a custom dummy node subclass of CSTNode that is neither
+    # a BaseStatement nor a BaseExpression to trigger the fallback.
+    # Use a plain object which is not a libcst node to trigger the
+    # conservative fallback path. Subclassing cst.CSTNode directly is
+    # abstract and cannot be instantiated.
+    dummy = object()
+    wrapped = wrap_small_stmt_if_needed(dummy)
+    assert isinstance(wrapped, cst.SimpleStatementLine)
+    assert isinstance(wrapped.body[0], cst.Pass)


### PR DESCRIPTION
This pull request introduces a set of improvements focused on refactoring and enhancing the robustness of the transformation logic, particularly around caplog handling and debug observability. The changes extract duplicated logic into dedicated helper modules, add debug gating for transformation failures, and introduce new unit tests and CI workflows to ensure reliability. These updates aim to reduce complexity, improve maintainability, and make debugging easier during development and CI.

Refactoring and Extraction:

* Extracted caplog alias detection and AST construction logic from `assert_transformer.py` into a new helper module `splurge_unittest_to_pytest.transformers._caplog_helpers`, centralizing duplicate code and improving testability.
* Updated `assert_transformer.py` to delegate caplog-related behavior to the new helpers and re-export thin compatibility shims to preserve public APIs. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL1-R16) [[2]](diffhunk://#diff-c92a166d88bb8fae4f896d43adf0ae698006eb168f61f4609128b7a565def052R1-R181)

Debugging and Observability:

* Added `splurge_unittest_to_pytest.transformers.debug` module with a debug gate (`get_transform_debug()`) and a `maybe_reraise()` helper, enabling re-raising of transformation exceptions when `SPLURGE_TRANSFORM_DEBUG` is set for easier debugging. [[1]](diffhunk://#diff-c92a166d88bb8fae4f896d43adf0ae698006eb168f61f4609128b7a565def052R1-R181) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL1-R16)
* Created a new GitHub Actions workflow `.github/workflows/pr-debug-tests.yml` to run the test suite with `SPLURGE_TRANSFORM_DEBUG=1` for PR verification, surfacing transformation failures early in CI.

Testing and Documentation:

* Added unit tests for caplog helpers (`tests/unit/test_caplog_helpers_basic.py`) and debug gate behavior (`tests/unit/test_debug_gate_basic.py`) to validate the new functionality and refactors. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL1-R16) [[2]](diffhunk://#diff-c92a166d88bb8fae4f896d43adf0ae698006eb168f61f4609128b7a565def052R1-R181)
* Documented the implementation plan, rationale, contracts, and acceptance criteria for the refactors and improvements in `docs/plans/plan-improvements-implementation-2025-10-03.md`.